### PR TITLE
Enhance onboarding, file operations, and improve data persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Typwriter** is a flexible, modern editor for [Typst](https://typst.app/), built with Tauri and Svelte. It allows you to write Typst documents, see a live preview of the compiled output, and export your documents directly to PDF, SVG and PNG.
 
+Note: Android version is currently buggy and not recommended for real use, I won't focus on it for now.
+
 ## Features
 
 I have implemented most of the editor features in the official [web app](https://typst.app/)

--- a/apps/typwriter-desktop/CLAUDE.md
+++ b/apps/typwriter-desktop/CLAUDE.md
@@ -13,9 +13,9 @@ The Typst editor. Tauri 2 + SvelteKit (static adapter) + a Rust core that wraps 
 
 ### Rust core (`src-tauri/src/`)
 
-- `lib.rs` — `run()` builds the Tauri app: registers the `previewimg://` URI scheme, initializes plugins, constructs shared state, spawns background font loading, and lists every `#[tauri::command]` in `invoke_handler!`.
-- `world/` — `EditorWorld<R: Runtime>` implements `typst::World` + `typst_ide::IdeWorld`. Owns fonts, source files, and the lazily-fetched package index. `progress.rs` emits package-download progress events to the frontend.
-- `compiler/` — `PreviewPipeline` (background worker), `compile.rs`, `render.rs`, `diff.rs`, `cache.rs`. Renders pages and serves them through the `previewimg://` protocol keyed by content fingerprint.
+- `lib.rs` — `run()` builds the Tauri app: registers the `previewimg://` URI scheme, initializes plugins, constructs shared state, and lists every `#[tauri::command]` in `invoke_handler!`.
+- `world/` — `EditorWorld<R: Runtime>` implements `typst::World` + `typst_ide::IdeWorld`. Owns fonts, source files, and the lazily-fetched package index. Fonts load lazily: `ensure_fonts_loading` (called on workspace open, and by the compile worker as a safety net) kicks off the background font search once; the compile worker calls `wait_until_fonts_loaded` so it never renders against the empty fallback book. `progress.rs` emits package-download progress events to the frontend.
+- `compiler/` — `PreviewPipeline` (background worker), `compile.rs`, `render.rs`, `diff.rs`, `cache.rs`, `disk_cache.rs`. Renders pages and serves them through the `previewimg://` protocol keyed by content fingerprint. The compile worker blocks on `EditorWorld::wait_until_fonts_loaded` before its first compile (fonts load lazily). `disk_cache.rs` persists rendered PNGs **and** a `preview-manifest.json` (ordered page keys + main file) so `restore_preview` can paint a re-opened workspace's preview from disk immediately, before the recompile finishes; the pane pulls this via `sync_preview`/`emit_current_state` on mount.
 - `workspace/` — `WorkspaceState`, filesystem `watcher`, path helpers, recent-workspaces store.
 - `commands/` — Tauri commands, grouped by domain: `app`, `editor`, `workspace`, `preview`, `click` (bidirectional source↔preview jump), `export` (PDF/PNG/SVG, with `_to_uri` variants for Android SAF), `format` (typstyle), `settings`, `logs`.
 

--- a/apps/typwriter-desktop/docs/onboarding-design.md
+++ b/apps/typwriter-desktop/docs/onboarding-design.md
@@ -1,0 +1,340 @@
+# Onboarding Screen — Design
+
+Status: **proposal / for review** · Scope: desktop only (first pass) · Author: design draft
+
+A first-launch, multi-step onboarding that teaches the **core Typst markup basics**
+(the material on <https://typst.app/docs/tutorial/writing-in-typst/>) using a live,
+editable example with a mini preview. Whether the user finishes or skips, we record
+that onboarding has been **shown** so it never auto-appears again. It stays replayable
+from the Home screen.
+
+---
+
+## 1. Goals & non-goals
+
+**Goals**
+
+- Teach Typst essentials interactively: markup, headings, emphasis, lists, math, the
+  `#` function syntax — each step with an editable snippet and a rendered preview.
+- Persist a single "onboarding shown" flag on the Rust side. Skip counts as shown.
+- Auto-show exactly once on first launch; expose a manual **replay** entry afterwards.
+- Reuse the existing editor + preview machinery rather than building a parallel renderer.
+
+**Non-goals (this pass)**
+
+- Mobile/Android layout. Onboarding is gated **off** on Android for now (`platform.isMobile`
+  short-circuits the auto-show and hides the replay entry). The flag still exists everywhere.
+- Teaching set/show rules, templates, scripting depth. We end by pointing to
+  <https://typst.app/docs/> for "read more".
+- Multi-file examples, packages, bibliography.
+
+---
+
+## 2. Preview strategy — scratch workspace (chosen)
+
+The live preview is **workspace-bound**: there is one `WorkspaceState` and one
+`PreviewPipeline` managed as Tauri state ([lib.rs:143](apps/typwriter-desktop/src-tauri/src/lib.rs#L143)),
+keyed to a single main `.typ` file, streamed to the webview over `previewimg://` by
+content fingerprint. It cannot render an arbitrary in-memory string directly.
+
+Rather than add a second renderer, onboarding **drives those same singletons** through a
+disposable "scratch" workspace:
+
+- On first launch the app sits on the Home page — **no workspace is open**, so commandeering
+  the singletons for onboarding is safe.
+- Onboarding opens a scratch workspace under app data (e.g.
+  `app_data_dir/onboarding/`), with one main file `main.typ`.
+- Each step **writes its example** into `main.typ`, opens it in the editor, and lets the
+  normal flow render it: keystroke → shadow write (`update_file_content`) →
+  `trigger_preview('typing')` → pipeline compiles → `previewimg://` → preview pane.
+  This is exactly the path in [editor.svelte.ts](apps/typwriter-desktop/src/lib/stores/editor.svelte.ts)
+  (`handleTabContentChange` → `_fireTypingPreview`).
+- The "mini editor" and "mini preview" are the **existing** editor + preview components,
+  rendered in a constrained two-pane layout — not new widgets.
+
+**Why this over a `compile_snippet` command:** zero new Rust compile path, identical
+typing/diagnostics/zoom behaviour to the real editor, and the user practises in the actual
+tool. **Cost / risks** (see §8): the singletons are global, so we must guarantee the user
+isn't mid-workspace, and we must tear the scratch workspace down cleanly on exit.
+
+### 2.1 Lifecycle of the scratch workspace
+
+```
+enter onboarding
+  └─ guard: if a real workspace is open, confirm before hijacking it (see §8)
+  └─ ensure scratch dir exists (Rust: get/create onboarding dir)
+  └─ workspace.init(scratchPath)          // reuses existing init: opens folder, sets up watcher
+  └─ for each step: write example → editor.openFile("main.typ") → triggerPreview
+exit (finish OR skip)
+  └─ editor.flushAllTabs() is NOT needed (scratch content is throwaway)
+  └─ workspace.leave()                     // existing teardown: disposes watcher, clears preview
+  └─ mark onboarding shown (Rust)
+  └─ page.navigate("home")
+```
+
+`workspace.init` / `workspace.leave` already exist and already reset the editor + preview
+stores ([workspace.svelte.ts:186](apps/typwriter-desktop/src/lib/stores/workspace.svelte.ts#L186),
+[:250](apps/typwriter-desktop/src/lib/stores/workspace.svelte.ts#L250)). We lean on them
+instead of inventing teardown.
+
+---
+
+## 3. Rust side — the "shown" flag
+
+### 3.1 Storage
+
+Add one field to the existing persisted settings
+([settings.rs:32](apps/typwriter-desktop/src-tauri/src/commands/settings.rs#L32)):
+
+```rust
+pub struct AppSettings {
+    // …existing fields…
+    /// Set to true once the onboarding flow has been shown (completed OR skipped).
+    pub onboarding_completed: bool,
+}
+```
+
+**Decided:** default `false` in `impl Default`, so existing users on upgrade also see
+onboarding once (it's opt-out via Skip).
+
+This piggybacks on `app_data.json` via `tauri-plugin-store` — the same mechanism the rest
+of settings use, persisted under `settings.ui`. No new store, no VCS involvement.
+
+### 3.2 Commands
+
+**Decided:** use two thin, dedicated commands (over reusing `get/set_app_settings`) so the
+frontend doesn't round-trip the whole settings blob just to read a bool, and intent is clear:
+
+```rust
+#[tauri::command]
+pub fn get_onboarding_completed(handle: AppHandle) -> bool { read_settings(&handle).onboarding_completed }
+
+#[tauri::command]
+pub fn set_onboarding_completed(handle: AppHandle, completed: bool) {
+    let mut s = read_settings(&handle);
+    s.onboarding_completed = completed;
+    write_settings(&handle, &s);
+}
+```
+
+Register both in the `invoke_handler!` list in
+[lib.rs:184](apps/typwriter-desktop/src-tauri/src/lib.rs#L184) and add the `settings` module
+re-export.
+
+A "scratch onboarding workspace directory" helper is also needed Rust-side (resolve
+`app_data_dir().join("onboarding")`, create if missing, return the path), so the frontend
+doesn't hardcode platform paths. Can live next to the workspace commands.
+
+---
+
+## 4. Frontend architecture
+
+### 4.1 New page
+
+Onboarding becomes a first-class page in the page store
+([page.svelte.ts:8](apps/typwriter-desktop/src/lib/stores/page.svelte.ts#L8)):
+
+```ts
+type PageName = "home" | "workspace" | "keymaps" | "settings" | "onboarding";
+// pages["onboarding"] = { name, component: Onboarding }
+```
+
+New component: `src/lib/components/pages/onboarding.svelte`.
+
+### 4.2 Auto-show on first launch
+
+In `home.svelte`'s `onMount` (it already gates on font readiness — the natural place):
+
+```ts
+// after fonts are confirmed ready, desktop only
+if (!platform.isMobile) {
+  const shown = await getOnboardingCompleted();
+  if (shown.isOk() && !shown.value) page.navigate("onboarding");
+}
+```
+
+Why here rather than `+page.svelte`: Home is the default landing page, fonts must be loaded
+before any compile/preview can succeed, and Home already owns that readiness handshake.
+Onboarding needs fonts too (it compiles examples), so gating behind `fontsReady` is correct.
+
+### 4.3 Replay entry
+
+Add a link button to Home's footer row alongside "Typst Docs"
+([home.svelte:437](apps/typwriter-desktop/src/lib/components/pages/home.svelte#L437)):
+
+```
+[ Tutorial ]  →  page.navigate("onboarding")   // desktop only
+```
+
+Replaying does **not** clear the flag — it just re-enters the page. (Optional: also surface
+it in Settings later.)
+
+### 4.4 Onboarding store
+
+`src/lib/stores/onboarding.svelte.ts` — a class singleton (per repo convention; module-level
+`$state` loses reactivity):
+
+```ts
+class OnboardingStore {
+  stepIndex = $state(0);
+  steps = STEPS;                       // static content array, §6
+  current = $derived(this.steps[this.stepIndex]);
+  isFirst = $derived(this.stepIndex === 0);
+  isLast  = $derived(this.stepIndex === this.steps.length - 1);
+  scratchReady = $state(false);
+
+  async enter(): ResultAsync<void,string> // ensure scratch ws, init workspace, load step 0
+  next() / prev() / goTo(i)              // writes step.example into main.typ, opens it
+  async finish()                         // set flag true, leave workspace, nav home
+  async skip()                           // identical to finish() (skip == shown)
+}
+```
+
+`next`/`prev` **preserve the user's edits**: each step keeps its own buffer in the store,
+seeded from the starter example on first visit and never overwritten on revisit. A per-step
+**"Reset example"** button restores the pristine snippet on demand. IPC methods return
+`ResultAsync<void,string>` per the neverthrow convention.
+
+### 4.5 Component layout (desktop)
+
+```
+┌─ onboarding.svelte ────────────────────────────────────────────────┐
+│  Titlebar (minimal, "Typwriter — Tutorial")          [Skip ✕]       │
+│  ┌────────────────────────┐  ┌──────────────────────────────────┐  │
+│  │  EXPLANATION (left)     │  │  EDITOR (top)                    │  │
+│  │  • step title           │  │   existing editor component on   │  │
+│  │  • prose explaining the │  │   scratch main.typ               │  │
+│  │    concept + how it maps │  ├──────────────────────────────────┤  │
+│  │    to the editor        │  │  MINI PREVIEW (bottom)           │  │
+│  │  • "try this" callout   │  │   existing preview component     │  │
+│  └────────────────────────┘  └──────────────────────────────────┘  │
+│  ●●●○○○○  step 4 / 7      [ Back ]                 [ Next → ]        │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+- Left/right split via the existing `Resizable.PaneGroup`; editor/preview split vertically
+  (mirrors the real workspace so the layout itself is part of the lesson).
+- Reuse the **editor pane** and **preview pane** components rather than CodeMirror raw —
+  they already wire content-sync, diagnostics, zoom, and the `previewimg://` fetch.
+- Footer: dot stepper + Back/Next; Next becomes **"Finish"** on the last step.
+- Skip (top-right ✕) available on every step → `onboarding.skip()`.
+- Keyboard: `Esc` = skip (with confirm), `←/→` = prev/next when focus isn't in the editor.
+
+---
+
+## 5. State / flag flow (summary)
+
+| Event                        | Action                                                            |
+|------------------------------|-------------------------------------------------------------------|
+| First launch, fonts ready    | `get_onboarding_completed` → `false` → auto `navigate("onboarding")` |
+| User clicks **Finish**       | `set_onboarding_completed(true)` → leave scratch ws → Home        |
+| User clicks **Skip** / `Esc` | identical to Finish (skip = shown)                                 |
+| Later launches               | flag `true` → no auto-show                                         |
+| Home → **Tutorial** button   | `navigate("onboarding")`, flag untouched                          |
+
+---
+
+## 6. Step content (Typst basics)
+
+Seven steps, tracking the "Writing in Typst" tutorial. Each step = `{ id, title, blurb,
+example, tryThis }`. Examples are short and self-contained so they compile instantly.
+
+1. **Welcome** — what Typst is (markup compiles to a typeset PDF), what the two panes are.
+   Example: a one-line `= Hello, Typst!` so the user sees text → rendered page immediately.
+2. **Headings & paragraphs** — `=`, `==`, `===` for heading levels; blank line = new
+   paragraph. *Try:* add a `==` subheading.
+3. **Emphasis** — `*bold*` and `_italic_`. *Try:* make a word bold.
+4. **Lists** — `-` bullet lists and `+` numbered lists; nesting by indentation. *Try:* add
+   a third item.
+5. **Math** — inline `$a^2 + b^2$` and block `$ ... $` equations. *Try:* change the exponent.
+6. **Functions & the `#`** — markup vs. code; calling a function with `#`
+   (`#lorem(20)`, `#image("...")` mentioned but not run since scratch has no asset),
+   `#text(fill: red)[...]`. *Try:* wrap text in `#text(fill: blue)[...]`.
+7. **You're ready** — recap; primary button **"Open the docs"** →
+   `openUrl("https://typst.app/docs/")`; secondary **"Start writing"** → Finish → Home.
+
+Exact prose to be written during implementation; the skeleton above defines structure and
+the editable snippet per step. (Content review welcome — happy to expand to 8 steps if we
+want a dedicated "set rules" teaser.)
+
+---
+
+## 7. Files touched
+
+**Rust**
+- `src-tauri/src/commands/settings.rs` — add `onboarding_completed` field + `get/set_onboarding_completed`.
+- `src-tauri/src/commands/workspace.rs` (or `app.rs`) — scratch onboarding dir helper command.
+- `src-tauri/src/lib.rs` — register the new commands.
+
+**Frontend**
+- `src/lib/components/pages/onboarding.svelte` — new page (layout in §4.5).
+- `src/lib/components/onboarding/` — small pieces: `step-explanation.svelte`, `stepper.svelte`
+  (keep `onboarding.svelte` thin).
+- `src/lib/stores/onboarding.svelte.ts` — new store singleton.
+- `src/lib/stores/page.svelte.ts` — register `onboarding` page.
+- `src/lib/ipc/commands.ts` — `getOnboardingCompleted`, `setOnboardingCompleted`,
+  `getOnboardingDir` wrappers (neverthrow `ResultAsync`).
+- `src/lib/components/pages/home.svelte` — first-launch auto-show in `onMount`; "Tutorial"
+  link in footer (desktop only).
+
+---
+
+## 8. Resolved decisions
+
+1. **Existing-user behaviour on upgrade — DECIDED: show once to everyone.**
+   `onboarding_completed` defaults to `false`, so users upgrading to this build also see
+   onboarding a single time (opt-out via Skip).
+2. **Per-step buffer — DECIDED: preserve edits.** Each step owns its buffer, seeded from the
+   starter example on first visit and never auto-overwritten on revisit. A per-step
+   "Reset example" button restores the pristine snippet on demand.
+3. **Scratch workspace cleanup — DECIDED: leave on disk between runs.** Lives in a
+   Tauri-provided app directory (`app_data_dir/onboarding/`); kept so replay is instant.
+4. **Flag commands — DECIDED: dedicated `get/set_onboarding_completed`** rather than reusing
+   `get/set_app_settings`.
+
+Remaining guardrails (no decision needed, just noted):
+
+- **Singleton hijack guard.** Onboarding is only reachable from Home, where no workspace is
+  open; `enter()` asserts `workspace.rootPath === null` before commandeering the singletons.
+- **Fonts.** Onboarding compiles, so auto-show is sequenced after Home's `fontsReady`
+  handshake (§4.2).
+
+---
+
+## 8b. Implementation notes (as built)
+
+Deviations from the draft above, all for correctness:
+
+- **Flag lives under its own store key, not in `AppSettings`.** The Settings page
+  round-trips the whole `AppSettings` struct through `set_app_settings`; a payload missing
+  the field would let serde reset it to `false`. The flag is stored under
+  `settings.onboarding_completed` via `get/set_onboarding_completed`, fully decoupled.
+- **One file per step, not a single re-seeded `main.typ`.** `prepare_onboarding_workspace`
+  takes `Vec<{name, content}>` and seeds one `*.typ` per step (named by step id), via plain
+  `std::fs` (it runs *before* the world is bound to the dir, so `save_file` isn't usable).
+  Navigating to a step makes that step's file the **main file**, so every step compiles a
+  genuinely distinct document. This is the fix for the stale-preview bug: with a single
+  swapped `main.typ`, the per-workspace preview cache + `last_emitted` page list (both
+  intentionally persistent across opens of the *same* dir, which the scratch workspace
+  reuses) could serve a previous step's — or previous session's — render for the current
+  step. Distinct main files make that impossible.
+- **Tab-less minimal editor, decoupled from the `editor`/`workspace` stores.**
+  `onboarding-editor.svelte` is a single controlled CodeMirror (`value` + monotonic
+  `seedVersion` in, `onchange` out) with Typst highlighting, theme, and font — no tabs, no
+  IPC, no shared-store coupling. The onboarding store drives the world directly via
+  `open_folder` → `set_main_file` → `update_file_content` (shadow) → `trigger_preview`,
+  bypassing the tabbed-editor machinery entirely. Typing debounces a shadow-write +
+  `trigger_preview('typing')`; step change / "Reset example" bump `seedVersion` (reseeding
+  the editor) and force an `explicit` recompile after `preview.clear()`.
+- **Recents exclusion.** `add_recent_workspace` skips `<app_data>/onboarding`, so the
+  scratch workspace never appears in Home's "Recent Workspaces" list (crash-safe — handled
+  at the source rather than cleaned up after).
+
+## 9. Suggested implementation order
+
+1. Rust: add field + commands + scratch-dir helper; `cargo check`.
+2. Frontend plumbing: IPC wrappers, page-store entry, empty `onboarding.svelte` that just
+   enters/leaves a scratch workspace and renders editor+preview.
+3. Step model + content array + stepper/explanation UI + navigation.
+4. First-launch auto-show + Home "Tutorial" link.
+5. Polish: keyboard shortcuts, reset-example, Esc-confirm, copy pass.

--- a/apps/typwriter-desktop/package.json
+++ b/apps/typwriter-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typwriter",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/apps/typwriter-desktop/src-tauri/Cargo.lock
+++ b/apps/typwriter-desktop/src-tauri/Cargo.lock
@@ -6808,7 +6808,7 @@ dependencies = [
 
 [[package]]
 name = "typwriter"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/apps/typwriter-desktop/src-tauri/Cargo.toml
+++ b/apps/typwriter-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typwriter"
-version = "0.8.0"
+version = "0.8.1"
 description = "A typsetting app built on top of typst, with a desktop interface built using Tauri."
 authors = ["ade"]
 edition = "2021"

--- a/apps/typwriter-desktop/src-tauri/src/commands/app.rs
+++ b/apps/typwriter-desktop/src-tauri/src/commands/app.rs
@@ -1,15 +1,15 @@
 use std::path::Path;
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::Arc;
 
 use log::info;
 use serde::Deserialize;
 use tauri::{AppHandle, Manager, State};
 
-use crate::AppInit;
+use crate::world::EditorWorld;
 
 #[tauri::command]
-pub fn is_fonts_loaded(init: State<'_, Arc<AppInit>>) -> bool {
-    init.fonts_loaded.load(Ordering::Acquire)
+pub fn is_fonts_loaded(world: State<'_, Arc<EditorWorld>>) -> bool {
+    world.fonts_ready()
 }
 
 /// One seed file for the onboarding workspace: a bare file name plus its

--- a/apps/typwriter-desktop/src-tauri/src/commands/app.rs
+++ b/apps/typwriter-desktop/src-tauri/src/commands/app.rs
@@ -1,10 +1,65 @@
+use std::path::Path;
 use std::sync::{atomic::Ordering, Arc};
 
-use tauri::State;
+use log::info;
+use serde::Deserialize;
+use tauri::{AppHandle, Manager, State};
 
 use crate::AppInit;
 
 #[tauri::command]
 pub fn is_fonts_loaded(init: State<'_, Arc<AppInit>>) -> bool {
     init.fonts_loaded.load(Ordering::Acquire)
+}
+
+/// One seed file for the onboarding workspace: a bare file name plus its
+/// starting Typst source.
+#[derive(Deserialize)]
+pub struct OnboardingFile {
+    name: String,
+    content: String,
+}
+
+/// Prepare the disposable workspace used by the onboarding tutorial.
+///
+/// Lives under the Tauri-provided app-data directory (`<app_data>/onboarding`)
+/// and is kept between runs so replaying the tutorial is instant. Each tutorial
+/// step is its own `*.typ` file — giving every step a distinct *main file* is
+/// what keeps the preview pipeline from ever serving one step's cached render
+/// for another. The files are (re)seeded here via plain `std::fs`, which runs
+/// *before* `WorkspaceState::open_folder` rebinds the editor world (so we can't
+/// go through `save_file`, which resolves paths against the world root). Each
+/// entry starts pristine on disk; in-session edits live in the editor world's
+/// shadow buffers, not on disk.
+#[tauri::command]
+pub fn prepare_onboarding_workspace(
+    files: Vec<OnboardingFile>,
+    app: AppHandle,
+) -> Result<String, String> {
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
+    let dir = base.join("onboarding");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create onboarding dir: {e}"))?;
+
+    for file in &files {
+        // Only accept a bare file name — guard against path traversal escaping
+        // the scratch directory.
+        let name = Path::new(&file.name)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .filter(|n| *n == file.name)
+            .ok_or_else(|| format!("Invalid onboarding file name: {}", file.name))?;
+        let target = dir.join(name);
+        std::fs::write(&target, &file.content)
+            .map_err(|e| format!("Failed to seed {name}: {e}"))?;
+    }
+
+    let path = dir.to_string_lossy().into_owned();
+    info!(
+        "prepare_onboarding_workspace: ready at {path:?} ({} files)",
+        files.len()
+    );
+    Ok(path)
 }

--- a/apps/typwriter-desktop/src-tauri/src/commands/editor.rs
+++ b/apps/typwriter-desktop/src-tauri/src/commands/editor.rs
@@ -8,6 +8,7 @@
 
 use std::{path::Path, sync::Arc, time::Instant};
 
+use base64::Engine;
 use ecow::EcoString;
 use log::{debug, error, info, warn};
 use parking_lot::RwLock;
@@ -134,8 +135,18 @@ pub enum JumpResponse {
 #[derive(Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum FileContentResponse {
-    Text { content: String },
-    Image { path: String, mime: String },
+    Text {
+        content: String,
+    },
+    Image {
+        path: String,
+        mime: String,
+        /// Inline `data:` URL with the image bytes, populated only when the
+        /// workspace root is behind Android's Storage Access Framework — there
+        /// `convertFileSrc`/the asset protocol can't reach the file, so the
+        /// frontend renders these bytes directly instead of fetching `path`.
+        data: Option<String>,
+    },
     Unsupported,
 }
 
@@ -143,9 +154,18 @@ pub enum FileContentResponse {
 
 /// Read a file from disk and return its content.
 /// Text files are returned as UTF-8 strings; image files are returned as paths
-/// that the frontend can convert into Tauri asset URLs.
+/// that the frontend can convert into Tauri asset URLs (or, for SAF roots, as
+/// inline `data:` URLs since the asset protocol can't reach them).
+///
+/// Reads route through the workspace's [`WorkingTreeFs`], so a folder picked
+/// via Android's Storage Access Framework — invisible to `std::fs` — is
+/// readable just like an app-managed or desktop folder.
 #[tauri::command]
-pub fn read_file(path: String) -> Result<FileContentResponse, String> {
+pub fn read_file(
+    path: String,
+    workspace: State<'_, Arc<WorkspaceState>>,
+    vcs: State<'_, Arc<VcsState>>,
+) -> Result<FileContentResponse, String> {
     let t = Instant::now();
     info!("read_file: path={path:?}");
 
@@ -155,6 +175,13 @@ pub fn read_file(path: String) -> Result<FileContentResponse, String> {
         .and_then(|e| e.to_str())
         .unwrap_or("")
         .to_ascii_lowercase();
+
+    // Resolve the SAF-aware accessor for the current workspace root. An empty
+    // root (no workspace open) maps to a plain std::fs accessor, since `abs` is
+    // always an absolute path the local filesystem can serve directly.
+    let root = workspace.root.read().clone().unwrap_or_default();
+    let fs = vcs.working_tree_fs_for(&root);
+    let is_saf = vcs.is_saf_root(&root);
 
     // Determine MIME type for image extensions
     let mime = match ext.as_str() {
@@ -171,6 +198,31 @@ pub fn read_file(path: String) -> Result<FileContentResponse, String> {
     };
 
     if let Some(mime) = mime {
+        // On a SAF root the asset protocol (std::fs-backed) can't reach the
+        // file, so read the bytes through android-fs and ship them inline as a
+        // data URL. Elsewhere keep returning a path the frontend turns into an
+        // asset URL — cheap, and avoids base64-bloating every image over IPC.
+        if is_saf {
+            let bytes = fs.read_file(abs).map_err(|e| {
+                error!(
+                    "read_file: saf read image failed path={path:?} err=\"{e}\" ({:.1}ms)",
+                    t.elapsed().as_secs_f64() * 1000.0
+                );
+                e
+            })?;
+            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            info!(
+                "read_file: ok saf image mime={mime} bytes={} ({:.1}ms)",
+                bytes.len(),
+                t.elapsed().as_secs_f64() * 1000.0
+            );
+            return Ok(FileContentResponse::Image {
+                path: abs.to_string_lossy().into_owned(),
+                mime: mime.to_string(),
+                data: Some(format!("data:{mime};base64,{encoded}")),
+            });
+        }
+
         let metadata = std::fs::metadata(abs).map_err(|e| {
             error!(
                 "read_file: io error reading image metadata path={path:?} err=\"{e}\" ({:.1}ms)",
@@ -186,6 +238,7 @@ pub fn read_file(path: String) -> Result<FileContentResponse, String> {
         return Ok(FileContentResponse::Image {
             path: abs.to_string_lossy().into_owned(),
             mime: mime.to_string(),
+            data: None,
         });
     }
 
@@ -217,9 +270,16 @@ pub fn read_file(path: String) -> Result<FileContentResponse, String> {
     );
 
     if is_text {
-        let content = std::fs::read_to_string(abs).map_err(|e| {
+        let bytes = fs.read_file(abs).map_err(|e| {
             error!(
                 "read_file: io error reading text path={path:?} err=\"{e}\" ({:.1}ms)",
+                t.elapsed().as_secs_f64() * 1000.0
+            );
+            e
+        })?;
+        let content = String::from_utf8(bytes).map_err(|e| {
+            error!(
+                "read_file: non-utf8 text path={path:?} err=\"{e}\" ({:.1}ms)",
                 t.elapsed().as_secs_f64() * 1000.0
             );
             e.to_string()
@@ -296,13 +356,18 @@ pub fn save_file(
         e.to_string()
     })?;
 
-    std::fs::write(abs, content.as_bytes()).map_err(|e| {
-        error!(
-            "save_file: io error path={path:?} err=\"{e}\" ({:.1}ms)",
-            t.elapsed().as_secs_f64() * 1000.0
-        );
-        e.to_string()
-    })?;
+    // Write through the SAF-aware accessor so saving works on a folder picked
+    // via Android's Storage Access Framework, not just on std::fs paths.
+    let root = workspace.root.read().clone().unwrap_or_default();
+    vcs.working_tree_fs_for(&root)
+        .write_file(abs, content.as_bytes())
+        .map_err(|e| {
+            error!(
+                "save_file: io error path={path:?} err=\"{e}\" ({:.1}ms)",
+                t.elapsed().as_secs_f64() * 1000.0
+            );
+            e
+        })?;
 
     // Remove the shadow since disk now matches the editor content.
     world.shadow_remove(id);

--- a/apps/typwriter-desktop/src-tauri/src/commands/format.rs
+++ b/apps/typwriter-desktop/src-tauri/src/commands/format.rs
@@ -403,6 +403,912 @@ mod tests {
         assert_eq!(locate_unique("aXb", "X"), Some(1));
         assert_eq!(locate_unique("abc", "X"), None);
     }
+
+    #[test]
+    fn locate_unique_at_string_boundaries() {
+        assert_eq!(locate_unique("Xabc", "X"), Some(0)); // at the very start
+        assert_eq!(locate_unique("abcX", "X"), Some(3)); // at the very end
+        assert_eq!(locate_unique("X", "X"), Some(0)); // whole string
+        assert_eq!(locate_unique("abc", "abc"), Some(0)); // needle == haystack
+    }
+
+    // ── utf16 ↔ byte conversions: edge cases ────────────────────────
+
+    #[test]
+    fn utf16_to_byte_offset_empty_string() {
+        assert_eq!(utf16_to_byte_offset("", 0), Some(0));
+        assert_eq!(utf16_to_byte_offset("", 1), None);
+    }
+
+    #[test]
+    fn utf16_to_byte_offset_out_of_range() {
+        let s = "hi";
+        assert_eq!(utf16_to_byte_offset(s, 2), Some(2)); // exactly the end
+        assert_eq!(utf16_to_byte_offset(s, 3), None); // one past the end
+        assert_eq!(utf16_to_byte_offset(s, 999), None);
+    }
+
+    #[test]
+    fn utf16_to_byte_offset_inside_surrogate_pair_rounds_forward() {
+        // "🦀" is one char: 4 bytes UTF-8, 2 units UTF-16 (a surrogate pair).
+        // An offset that lands *between* the surrogates rounds forward to the
+        // char boundary after the crab (byte 5), never splitting the char.
+        let s = "a🦀b";
+        assert_eq!(utf16_to_byte_offset(s, 2), Some(5));
+    }
+
+    #[test]
+    fn byte_to_utf16_offset_clamps_past_end() {
+        let s = "hi";
+        assert_eq!(byte_to_utf16_offset(s, 2), 2);
+        assert_eq!(byte_to_utf16_offset(s, 99), 2); // clamps to the end
+    }
+
+    #[test]
+    fn utf16_round_trip_mixed_multibyte_and_surrogates() {
+        // ASCII, 2-byte (é), 3-byte (€), and a surrogate-pair emoji (🦀).
+        let s = "a é € 🦀 b";
+        let units = count_utf16(s);
+        // Walk every char boundary; both directions must agree.
+        for (byte_idx, _) in s.char_indices() {
+            let u = byte_to_utf16_offset(s, byte_idx);
+            assert_eq!(
+                utf16_to_byte_offset(s, u),
+                Some(byte_idx),
+                "round trip failed at byte {byte_idx}"
+            );
+        }
+        // The end is reachable too.
+        assert_eq!(utf16_to_byte_offset(s, units), Some(s.len()));
+    }
+
+    #[test]
+    fn count_utf16_counts_code_units_not_chars() {
+        assert_eq!(count_utf16(""), 0);
+        assert_eq!(count_utf16("hello"), 5);
+        assert_eq!(count_utf16("é"), 1); // 2 bytes, 1 unit
+        assert_eq!(count_utf16("€"), 1); // 3 bytes, 1 unit
+        assert_eq!(count_utf16("🦀"), 2); // 4 bytes, surrogate pair → 2 units
+    }
+
+    // ── floor_char_boundary ─────────────────────────────────────────
+
+    #[test]
+    fn floor_char_boundary_ascii_is_identity_and_clamps() {
+        let s = "hello";
+        for i in 0..=s.len() {
+            assert_eq!(floor_char_boundary(s, i), i);
+        }
+        assert_eq!(floor_char_boundary(s, 99), s.len()); // past end → len
+    }
+
+    #[test]
+    fn floor_char_boundary_rounds_down_inside_multibyte() {
+        // "é" occupies bytes 1..3.
+        let s = "aébc";
+        assert_eq!(floor_char_boundary(s, 1), 1); // already aligned
+        assert_eq!(floor_char_boundary(s, 2), 1); // mid-é → floor to 1
+        assert_eq!(floor_char_boundary(s, 3), 3); // aligned again
+    }
+
+    #[test]
+    fn floor_char_boundary_rounds_down_inside_emoji() {
+        // "🦀" occupies bytes 1..5.
+        let s = "a🦀b";
+        assert_eq!(floor_char_boundary(s, 1), 1);
+        for mid in 2..=4 {
+            assert_eq!(floor_char_boundary(s, mid), 1, "byte {mid} should floor to 1");
+        }
+        assert_eq!(floor_char_boundary(s, 5), 5);
+    }
+
+    // ── parse_utf16_cursor ──────────────────────────────────────────
+
+    #[test]
+    fn parse_utf16_cursor_ok() {
+        let s = "aébc"; // é is 2 bytes
+        assert_eq!(parse_utf16_cursor(s, 0), Ok(0));
+        assert_eq!(parse_utf16_cursor(s, 2), Ok(3)); // after é
+        assert_eq!(parse_utf16_cursor(s, 4), Ok(5)); // end of string
+    }
+
+    #[test]
+    fn parse_utf16_cursor_out_of_range_is_err() {
+        let s = "abc";
+        let err = parse_utf16_cursor(s, 4).expect_err("should be out of range");
+        assert!(err.contains("out of range"), "unexpected message: {err}");
+        assert!(err.contains("utf16"), "unexpected message: {err}");
+    }
+
+    // ── make_cursor_marker against tricky sources ───────────────────
+
+    #[test]
+    fn marker_is_unique_against_multibyte_source() {
+        let source = "= Café ☕\nWith a crab 🦀 and a /* real comment */.\n";
+        let marker = make_cursor_marker(source);
+        assert!(!source.contains(&marker));
+        assert!(marker.starts_with("/*tw_cursor_"));
+        assert!(marker.ends_with("*/"));
+    }
+
+    #[test]
+    fn marker_avoids_an_existing_marker_like_string() {
+        // Source already contains a string shaped like our marker; the
+        // generated marker must still be absent from the source.
+        let source = "text /*tw_cursor_0000000000000000*/ more text";
+        let marker = make_cursor_marker(source);
+        assert!(!source.contains(&marker));
+    }
+
+    // ── format_typst_cursor_virtual: end-to-end cursor maintenance ───
+    //
+    // These run real typstyle. To stay robust against typstyle's exact
+    // whitespace decisions we assert *invariants* (marker never leaks, the
+    // cursor stays in bounds and on a char boundary) plus anchor checks that
+    // only depend on a sentinel surviving the reflow.
+
+    /// Convenience: run the command and unwrap.
+    fn fmt(source: &str, cursor_utf16: u32) -> FormatWithCursorResponse {
+        format_typst_cursor_virtual(source.to_string(), cursor_utf16)
+            .expect("format_typst_cursor_virtual should succeed")
+    }
+
+    /// utf16 cursor positioned at the byte where `anchor` first appears.
+    fn cursor_before(source: &str, anchor: &str) -> u32 {
+        let byte = source.find(anchor).expect("anchor present in source");
+        byte_to_utf16_offset(source, byte) as u32
+    }
+
+    /// Assert the universal post-conditions of the command.
+    fn assert_invariants(source: &str, res: &FormatWithCursorResponse) {
+        let marker_prefix = "/*tw_cursor_";
+        assert!(
+            !res.formatted.contains(marker_prefix),
+            "marker leaked into formatted output:\n{}",
+            res.formatted
+        );
+        let units = count_utf16(&res.formatted);
+        assert!(
+            res.cursor as usize <= units,
+            "cursor {} out of bounds (formatted has {units} utf16 units) for source {source:?}",
+            res.cursor
+        );
+        // The reported cursor must map back to a real char boundary.
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize);
+        assert!(
+            byte.is_some(),
+            "cursor {} does not land on a char boundary",
+            res.cursor
+        );
+    }
+
+    #[test]
+    fn cursor_virtual_empty_source() {
+        let res = fmt("", 0);
+        assert_invariants("", &res);
+        assert_eq!(res.cursor, 0);
+    }
+
+    #[test]
+    fn cursor_virtual_out_of_range_cursor_errors() {
+        let source = "#let x = 1\n";
+        let too_big = count_utf16(source) as u32 + 5;
+        let err = match format_typst_cursor_virtual(source.to_string(), too_big) {
+            Ok(_) => panic!("out-of-range cursor should error"),
+            Err(e) => e,
+        };
+        assert!(err.contains("out of range"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn cursor_virtual_at_start_stays_at_start() {
+        let source = "Hello world\n";
+        let res = fmt(source, 0);
+        assert_invariants(source, &res);
+        assert_eq!(res.cursor, 0, "cursor at offset 0 should remain at 0");
+    }
+
+    #[test]
+    fn cursor_virtual_at_end_stays_near_end() {
+        let source = "Hello world";
+        let res = fmt(source, count_utf16(source) as u32);
+        assert_invariants(source, &res);
+        // typstyle may append a trailing newline; the cursor should land at or
+        // just before the end, never before the final word.
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        assert!(
+            res.formatted[..byte].ends_with("world"),
+            "cursor should follow the last word; got prefix {:?}",
+            &res.formatted[..byte]
+        );
+    }
+
+    #[test]
+    fn cursor_follows_sentinel_through_whitespace_reflow() {
+        // typstyle collapses the runaway spaces in the code line, shifting the
+        // byte offset of the markup that follows. The cursor (placed right
+        // before the SENTINEL word) must move with it.
+        let source = "#let    x    =    1\nSENTINEL tail\n";
+        let res = fmt(source, cursor_before(source, "SENTINEL"));
+        assert_invariants(source, &res);
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        assert!(
+            res.formatted[byte..].starts_with("SENTINEL"),
+            "cursor should sit right before SENTINEL; got tail {:?}",
+            &res.formatted[byte..]
+        );
+    }
+
+    #[test]
+    fn cursor_neighborhood_preserved_in_already_formatted_source() {
+        // An already well-formatted document is (near) a no-op for typstyle, so
+        // the cursor's neighborhood must be byte-for-byte stable.
+        let source = "#let x = 1\n\nHello world\n";
+        let res = fmt(source, cursor_before(source, "world"));
+        assert_invariants(source, &res);
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        assert!(
+            res.formatted[byte..].starts_with("world"),
+            "cursor should sit right before 'world'; got tail {:?}",
+            &res.formatted[byte..]
+        );
+    }
+
+    #[test]
+    fn cursor_follows_sentinel_past_multibyte_and_emoji() {
+        // Multibyte (é, €) and a surrogate-pair emoji precede the cursor: the
+        // utf16 ↔ byte conversions on both ends must stay consistent.
+        let source = "Café € 🦀 SENTINEL done\n";
+        let res = fmt(source, cursor_before(source, "SENTINEL"));
+        assert_invariants(source, &res);
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        assert!(
+            res.formatted[byte..].starts_with("SENTINEL"),
+            "cursor should sit right before SENTINEL; got tail {:?}",
+            &res.formatted[byte..]
+        );
+    }
+
+    #[test]
+    fn cursor_inside_string_literal_returns_valid_output() {
+        // The cursor sits inside a string literal, where the spliced `/* */`
+        // marker is literal text rather than a comment. typstyle's handling
+        // here is implementation-defined, so we only assert the invariants:
+        // the function must succeed, never leak the marker, and return an
+        // in-bounds, boundary-aligned cursor (the clamp fallback guarantees
+        // this even when the marker can't be located).
+        let source = "#let s = \"hello world\"\n";
+        let cursor = cursor_before(source, "world");
+        let res = fmt(source, cursor);
+        assert_invariants(source, &res);
+    }
+
+    // ── Longer documents: formatting stability + cursor maintenance ──
+    //
+    // typstyle is idempotent: formatting already-formatted output must be a
+    // no-op. `assert_idempotent` re-formats the output and asserts it's stable,
+    // which is a strong correctness property that exercises the whole pipeline
+    // on realistic, multi-construct documents.
+
+    fn assert_idempotent(source: &str) {
+        let once = format_typst_source(source.to_string()).expect("first format should succeed");
+        let twice =
+            format_typst_source(once.clone()).expect("reformatting output should succeed");
+        assert_eq!(once, twice, "formatting is not idempotent for source:\n{source}");
+    }
+
+    /// A realistic mixed document: front-matter set rules, headings, prose with
+    /// irregular spacing, bullet + numbered + nested lists, inline and display
+    /// math, and a code definition. `SENTINEL` marks a stable cursor anchor.
+    const ACADEMIC_DOC: &str = r#"#set page(margin: 1in)
+#set text(font: "New Computer Modern", size: 11pt)
+
+= Introduction
+
+This paragraph has    some   irregular    spacing that typstyle will
+normalize, and we place a SENTINEL token here to anchor the cursor.
+
+== Background
+
+An unordered list:
+- first item
+- second item
+    - deeply nested item
+    - another nested item
+- third item
+
+An ordered list:
++ alpha
++ beta
++ gamma
+
+== Mathematics
+
+The inline equation $E = m c^2$ appears mid-sentence, followed by a
+display equation:
+
+$ integral_0^1 x^2 dif x = 1 / 3 $
+
+== Implementation
+
+#let greet(name) = [Hello, #name!]
+
+#greet("world")
+"#;
+
+    #[test]
+    fn long_academic_document_is_idempotent() {
+        assert_idempotent(ACADEMIC_DOC);
+    }
+
+    #[test]
+    fn cursor_maintained_in_long_academic_document() {
+        let res = fmt(ACADEMIC_DOC, cursor_before(ACADEMIC_DOC, "SENTINEL"));
+        assert_invariants(ACADEMIC_DOC, &res);
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        assert!(
+            res.formatted[byte..].starts_with("SENTINEL"),
+            "cursor should track SENTINEL through a long document; got tail {:?}",
+            &res.formatted[byte..].chars().take(20).collect::<String>()
+        );
+    }
+
+    #[test]
+    fn cursor_maintained_inside_nested_list_item() {
+        // Anchor sits inside a deeply nested list item — a spot where typstyle
+        // re-indents the surrounding structure.
+        let res = fmt(ACADEMIC_DOC, cursor_before(ACADEMIC_DOC, "deeply"));
+        assert_invariants(ACADEMIC_DOC, &res);
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        // typstyle re-indents the nested list and may insert a space after the
+        // spliced marker, so allow intervening whitespace — the cursor must
+        // still rest at the start of the same nested item, not drift away.
+        let tail = &res.formatted[byte..];
+        assert!(
+            tail.trim_start_matches([' ', '\t']).starts_with("deeply"),
+            "cursor should track the nested list item; got tail {:?}",
+            &tail.chars().take(20).collect::<String>()
+        );
+    }
+
+    #[test]
+    fn cursor_survives_two_consecutive_format_passes() {
+        // First pass on the raw (unformatted-spacing) document, then a second
+        // pass on the already-formatted output. The anchor must hold both
+        // times, and the second pass must leave the cursor's neighborhood
+        // untouched (idempotent text).
+        let first = fmt(ACADEMIC_DOC, cursor_before(ACADEMIC_DOC, "SENTINEL"));
+        assert_invariants(ACADEMIC_DOC, &first);
+
+        let second = fmt(&first.formatted, first.cursor);
+        assert_invariants(&first.formatted, &second);
+        let byte = utf16_to_byte_offset(&second.formatted, second.cursor as usize).unwrap();
+        assert!(
+            second.formatted[byte..].starts_with("SENTINEL"),
+            "cursor should still track SENTINEL after a second pass; got tail {:?}",
+            &second.formatted[byte..].chars().take(20).collect::<String>()
+        );
+        // The second pass is a no-op on the text itself.
+        assert_eq!(
+            first.formatted, second.formatted,
+            "a second format pass should not change already-formatted text"
+        );
+    }
+
+    const TABLE_DOC: &str = r#"= Results
+
+#table(
+  columns: 3,
+  table.header([Name], [Score], [Rank]),
+  [Alice], [95], [1],
+  [Bob], [87], [2],
+  [Carol], [SENTINEL], [3],
+)
+
+See the table above for the final standings.
+"#;
+
+    #[test]
+    fn table_document_is_idempotent() {
+        assert_idempotent(TABLE_DOC);
+    }
+
+    #[test]
+    fn cursor_maintained_inside_table_cell() {
+        let res = fmt(TABLE_DOC, cursor_before(TABLE_DOC, "SENTINEL"));
+        assert_invariants(TABLE_DOC, &res);
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        assert!(
+            res.formatted[byte..].starts_with("SENTINEL"),
+            "cursor should track the table cell; got tail {:?}",
+            &res.formatted[byte..].chars().take(20).collect::<String>()
+        );
+    }
+
+    const CODE_HEAVY_DOC: &str = r#"#import "@preview/example:0.1.0": thing
+
+#let fib(n) = {
+  if n <= 1 {
+    n
+  } else {
+    fib(n - 1) + fib(n - 2)
+  }
+}
+
+#let data = (
+  alpha: 1,
+  beta: 2,
+  gamma: 3,
+)
+
+The tenth Fibonacci number is #fib(10), and the SENTINEL follows.
+
+```rust
+// A raw block: typstyle must not reflow its contents.
+fn main() {
+    println!("hello   world");
+}
+```
+"#;
+
+    #[test]
+    fn code_heavy_document_is_idempotent() {
+        assert_idempotent(CODE_HEAVY_DOC);
+    }
+
+    #[test]
+    fn cursor_maintained_in_code_heavy_document() {
+        let res = fmt(CODE_HEAVY_DOC, cursor_before(CODE_HEAVY_DOC, "SENTINEL"));
+        assert_invariants(CODE_HEAVY_DOC, &res);
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        assert!(
+            res.formatted[byte..].starts_with("SENTINEL"),
+            "cursor should track text near code blocks; got tail {:?}",
+            &res.formatted[byte..].chars().take(20).collect::<String>()
+        );
+    }
+
+    #[test]
+    fn cursor_inside_raw_block_returns_valid_output() {
+        // The cursor lands inside a fenced raw block, where the spliced marker
+        // is literal text typstyle preserves verbatim. Behaviour is
+        // content-dependent, so assert invariants only.
+        let res = fmt(CODE_HEAVY_DOC, cursor_before(CODE_HEAVY_DOC, "hello"));
+        assert_invariants(CODE_HEAVY_DOC, &res);
+    }
+
+    #[test]
+    fn document_with_comments_is_idempotent() {
+        let source = r#"// A leading line comment.
+#set text(size: 12pt) // trailing comment
+
+= Title /* a block comment */ here
+
+Body paragraph with a SENTINEL anchor and /* inline */ a comment.
+"#;
+        assert_idempotent(source);
+    }
+
+    #[test]
+    fn cursor_maintained_in_very_long_generated_document() {
+        // Build a large document programmatically and place the anchor near the
+        // very end, exercising long-distance utf16 ↔ byte mapping.
+        let mut source = String::from("= Generated Report\n\n");
+        for i in 0..300 {
+            source.push_str(&format!(
+                "This is paragraph number {i}, containing enough prose to make the document long.\n\n"
+            ));
+        }
+        source.push_str("The final SENTINEL marker closes the report.\n");
+
+        let res = fmt(&source, cursor_before(&source, "SENTINEL"));
+        assert_invariants(&source, &res);
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        assert!(
+            res.formatted[byte..].starts_with("SENTINEL"),
+            "cursor should track SENTINEL near the end of a very long document"
+        );
+    }
+
+    #[test]
+    fn formatting_normalizes_then_stabilizes_messy_document() {
+        // A deliberately messy document (irregular spacing, blank-line runs)
+        // must format to something that is itself idempotent.
+        let messy = "=    Messy    Heading\n\n\n\nParagraph   with     gaps.\n\n\n#let    x=1\n";
+        let once = format_typst_source(messy.to_string()).expect("format should succeed");
+        assert!(!once.contains("=    Messy"), "heading spacing should be normalized");
+        assert_idempotent(&once);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Additional coverage: more unicode helper edge cases, and cursor
+    // maintenance / formatting stability across a wider set of Typst
+    // constructs (math, figures, show/set rules, citations, CRLF, named
+    // args, inline raw, CJK, combining marks, emoji).
+    // ════════════════════════════════════════════════════════════════
+
+    /// Assert the cursor in `res` rests right before `anchor`, allowing only
+    /// the leading whitespace typstyle may insert after the spliced marker.
+    fn assert_cursor_at_anchor(res: &FormatWithCursorResponse, anchor: &str) {
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize)
+            .expect("cursor must land on a char boundary");
+        let tail = &res.formatted[byte..];
+        assert!(
+            tail.trim_start_matches([' ', '\t']).starts_with(anchor),
+            "cursor should rest before {anchor:?}; got tail {:?}",
+            tail.chars().take(24).collect::<String>()
+        );
+    }
+
+    // ── More unicode helper edge cases ──────────────────────────────
+
+    #[test]
+    fn utf16_to_byte_offset_cjk() {
+        // Each CJK char is 3 bytes UTF-8 but a single UTF-16 unit.
+        let s = "a日本b";
+        assert_eq!(utf16_to_byte_offset(s, 0), Some(0));
+        assert_eq!(utf16_to_byte_offset(s, 1), Some(1)); // after 'a'
+        assert_eq!(utf16_to_byte_offset(s, 2), Some(4)); // after 日
+        assert_eq!(utf16_to_byte_offset(s, 3), Some(7)); // after 本
+        assert_eq!(utf16_to_byte_offset(s, 4), Some(8)); // after 'b'
+        assert_eq!(utf16_to_byte_offset(s, 5), None);
+    }
+
+    #[test]
+    fn byte_to_utf16_offset_cjk() {
+        let s = "a日本b";
+        assert_eq!(byte_to_utf16_offset(s, 0), 0);
+        assert_eq!(byte_to_utf16_offset(s, 1), 1);
+        assert_eq!(byte_to_utf16_offset(s, 4), 2);
+        assert_eq!(byte_to_utf16_offset(s, 7), 3);
+        assert_eq!(byte_to_utf16_offset(s, 8), 4);
+    }
+
+    #[test]
+    fn byte_to_utf16_offset_zero_is_zero() {
+        assert_eq!(byte_to_utf16_offset("", 0), 0);
+        assert_eq!(byte_to_utf16_offset("anything", 0), 0);
+    }
+
+    #[test]
+    fn utf16_round_trip_combining_diacritics() {
+        // "e" + combining acute accent: two codepoints, each one UTF-16 unit.
+        let s = "Cafe\u{0301}"; // renders as "Café" but is 5 codepoints
+        assert_eq!(count_utf16(s), 5);
+        for (byte_idx, _) in s.char_indices() {
+            let u = byte_to_utf16_offset(s, byte_idx);
+            assert_eq!(utf16_to_byte_offset(s, u), Some(byte_idx));
+        }
+        assert_eq!(utf16_to_byte_offset(s, 5), Some(s.len()));
+    }
+
+    #[test]
+    fn utf16_to_byte_offset_multiple_emojis() {
+        // Two surrogate-pair emoji: 2 UTF-16 units each.
+        let s = "🦀🎉";
+        assert_eq!(utf16_to_byte_offset(s, 0), Some(0));
+        assert_eq!(utf16_to_byte_offset(s, 2), Some(4)); // after the crab
+        assert_eq!(utf16_to_byte_offset(s, 4), Some(8)); // after the party
+        // Offsets landing mid-surrogate round forward to the next boundary.
+        assert_eq!(utf16_to_byte_offset(s, 1), Some(4));
+        assert_eq!(utf16_to_byte_offset(s, 3), Some(8));
+    }
+
+    #[test]
+    fn floor_char_boundary_inside_cjk() {
+        // 日 occupies bytes 1..4.
+        let s = "a日b";
+        assert_eq!(floor_char_boundary(s, 1), 1);
+        assert_eq!(floor_char_boundary(s, 2), 1);
+        assert_eq!(floor_char_boundary(s, 3), 1);
+        assert_eq!(floor_char_boundary(s, 4), 4);
+    }
+
+    #[test]
+    fn floor_char_boundary_empty_string() {
+        assert_eq!(floor_char_boundary("", 0), 0);
+        assert_eq!(floor_char_boundary("", 5), 0);
+    }
+
+    #[test]
+    fn floor_char_boundary_is_idempotent() {
+        let s = "a🦀é日b";
+        for i in 0..=s.len() + 3 {
+            let once = floor_char_boundary(s, i);
+            assert_eq!(floor_char_boundary(s, once), once, "not idempotent at {i}");
+        }
+    }
+
+    #[test]
+    fn count_utf16_matches_encode_utf16_len() {
+        let samples = ["", "ascii", "aé€🦀日", "Cafe\u{0301}", "🎉🚀✨"];
+        for s in samples {
+            assert_eq!(count_utf16(s), s.encode_utf16().count());
+        }
+    }
+
+    #[test]
+    fn make_cursor_marker_on_empty_source() {
+        let marker = make_cursor_marker("");
+        assert!(marker.starts_with("/*tw_cursor_"));
+        assert!(marker.ends_with("*/"));
+    }
+
+    #[test]
+    fn make_cursor_marker_has_hex_body_of_expected_shape() {
+        let marker = make_cursor_marker("some source");
+        // "/*tw_cursor_" + 16 hex digits + "*/"
+        assert_eq!(marker.len(), "/*tw_cursor_".len() + 16 + "*/".len());
+        let hex = &marker["/*tw_cursor_".len()..marker.len() - "*/".len()];
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()), "non-hex body: {hex}");
+    }
+
+    #[test]
+    fn locate_unique_multichar_needle() {
+        assert_eq!(locate_unique("foo bar baz", "bar"), Some(4));
+        assert_eq!(locate_unique("ab ab", "ab"), None); // duplicated
+        assert_eq!(locate_unique("hello", "xyz"), None); // absent
+    }
+
+    #[test]
+    fn parse_utf16_cursor_zero_and_exact_end() {
+        let s = "héllo"; // é is 2 bytes
+        assert_eq!(parse_utf16_cursor(s, 0), Ok(0));
+        assert_eq!(parse_utf16_cursor(s, count_utf16(s) as u32), Ok(s.len()));
+    }
+
+    #[test]
+    fn utf16_byte_round_trip_over_generated_mixed_string() {
+        // A longer programmatically built string mixing every width class.
+        let mut s = String::new();
+        for _ in 0..50 {
+            s.push_str("aé€日🦀");
+        }
+        for (byte_idx, _) in s.char_indices() {
+            let u = byte_to_utf16_offset(&s, byte_idx);
+            assert_eq!(utf16_to_byte_offset(&s, u), Some(byte_idx));
+        }
+    }
+
+    // ── Math documents ──────────────────────────────────────────────
+
+    const MATH_DOC: &str = r#"= Equations
+
+Inline math $a^2 + b^2 = c^2$ and a SENTINEL right after it.
+
+A display equation with a fraction and an integral:
+
+$ f(x) = integral_(-oo)^(oo) e^(-x^2) dif x = sqrt(pi) $
+
+Identity matrix:
+
+$ mat(1, 0; 0, 1) $
+"#;
+
+    #[test]
+    fn math_document_is_idempotent() {
+        assert_idempotent(MATH_DOC);
+    }
+
+    #[test]
+    fn cursor_maintained_after_inline_math() {
+        let res = fmt(MATH_DOC, cursor_before(MATH_DOC, "SENTINEL"));
+        assert_invariants(MATH_DOC, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    #[test]
+    fn cursor_inside_display_math_returns_valid_output() {
+        // Anchor inside a display equation; typstyle reflows math internals, so
+        // assert invariants only.
+        let res = fmt(MATH_DOC, cursor_before(MATH_DOC, "integral"));
+        assert_invariants(MATH_DOC, &res);
+    }
+
+    // ── Figures, labels, references ─────────────────────────────────
+
+    const FIGURE_DOC: &str = r#"= Figures
+
+#figure(
+  rect(width: 4cm, height: 2cm),
+  caption: [A SENTINEL placeholder figure.],
+) <fig:demo>
+
+As shown in @fig:demo, the placeholder renders correctly.
+"#;
+
+    #[test]
+    fn figure_document_is_idempotent() {
+        assert_idempotent(FIGURE_DOC);
+    }
+
+    #[test]
+    fn cursor_maintained_in_figure_caption() {
+        let res = fmt(FIGURE_DOC, cursor_before(FIGURE_DOC, "SENTINEL"));
+        assert_invariants(FIGURE_DOC, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    #[test]
+    fn cursor_maintained_near_reference() {
+        let res = fmt(FIGURE_DOC, cursor_before(FIGURE_DOC, "@fig:demo, the"));
+        assert_invariants(FIGURE_DOC, &res);
+        assert_cursor_at_anchor(&res, "@fig:demo");
+    }
+
+    // ── Show / set rules ────────────────────────────────────────────
+
+    const SHOWRULE_DOC: &str = r#"#show heading: set text(navy)
+#show "TODO": strong[TODO]
+#set par(justify: true)
+
+= Styled Heading
+
+A justified paragraph that contains a SENTINEL anchor in the middle.
+"#;
+
+    #[test]
+    fn show_rule_document_is_idempotent() {
+        assert_idempotent(SHOWRULE_DOC);
+    }
+
+    #[test]
+    fn cursor_maintained_with_show_rules() {
+        let res = fmt(SHOWRULE_DOC, cursor_before(SHOWRULE_DOC, "SENTINEL"));
+        assert_invariants(SHOWRULE_DOC, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    // ── Citations / bibliography ────────────────────────────────────
+
+    const CITE_DOC: &str = r#"= Related Work
+
+Prior work @smith2020 established the SENTINEL baseline, later extended
+by others @jones2021 in a follow-up study.
+
+#bibliography("refs.bib")
+"#;
+
+    #[test]
+    fn citation_document_is_idempotent() {
+        assert_idempotent(CITE_DOC);
+    }
+
+    #[test]
+    fn cursor_maintained_near_citation() {
+        let res = fmt(CITE_DOC, cursor_before(CITE_DOC, "SENTINEL"));
+        assert_invariants(CITE_DOC, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    // ── CRLF line endings ───────────────────────────────────────────
+
+    #[test]
+    fn crlf_document_formats_successfully() {
+        let source = "= Title\r\n\r\nA paragraph with a SENTINEL anchor and more text.\r\n";
+        let res = fmt(source, cursor_before(source, "SENTINEL"));
+        assert_invariants(source, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    #[test]
+    fn crlf_source_is_handled_by_pure_format() {
+        let source = "#let x = 1\r\n#let y = 2\r\n\r\nBody text here.\r\n";
+        // Whatever typstyle decides for line endings, the call must succeed and
+        // produce a non-empty, idempotent result.
+        let once = format_typst_source(source.to_string()).expect("format should succeed");
+        assert!(!once.is_empty());
+        assert_idempotent(&once);
+    }
+
+    // ── Named function arguments / content blocks ───────────────────
+
+    const NAMED_ARGS_DOC: &str = r#"#let card(title: "", body) = box(
+  stroke: 1pt,
+  inset: 8pt,
+)[
+  *#title* SENTINEL #body
+]
+
+#card(title: "Hello")[Some body content goes here.]
+"#;
+
+    #[test]
+    fn named_args_document_is_idempotent() {
+        assert_idempotent(NAMED_ARGS_DOC);
+    }
+
+    #[test]
+    fn cursor_maintained_in_content_block_with_named_args() {
+        let res = fmt(NAMED_ARGS_DOC, cursor_before(NAMED_ARGS_DOC, "SENTINEL"));
+        assert_invariants(NAMED_ARGS_DOC, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    // ── Inline raw, blank-line runs, headings ───────────────────────
+
+    #[test]
+    fn cursor_maintained_after_inline_raw_code() {
+        let source = "Use the `format_text` function then SENTINEL to continue.\n";
+        let res = fmt(source, cursor_before(source, "SENTINEL"));
+        assert_invariants(source, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    #[test]
+    fn cursor_maintained_through_blank_line_runs() {
+        // Several blank lines that typstyle collapses; the anchor sits after.
+        let source = "First paragraph.\n\n\n\n\n\nSENTINEL second paragraph.\n";
+        let res = fmt(source, cursor_before(source, "SENTINEL"));
+        assert_invariants(source, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    #[test]
+    fn cursor_maintained_before_a_heading() {
+        let source = "Intro paragraph.\n\n= SENTINEL Heading\n\nMore body text.\n";
+        let res = fmt(source, cursor_before(source, "SENTINEL"));
+        assert_invariants(source, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    // ── CJK, combining marks, emoji before the cursor ───────────────
+
+    #[test]
+    fn cursor_maintained_with_cjk_text_before_it() {
+        let source = "日本語のテキストです。 SENTINEL 続きの文章。\n";
+        let res = fmt(source, cursor_before(source, "SENTINEL"));
+        assert_invariants(source, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    #[test]
+    fn cursor_maintained_with_combining_diacritics_before_it() {
+        // Precompose-free text: each accent is a separate combining codepoint.
+        let source = "Cafe\u{0301} a\u{0300} la mode SENTINEL dessert.\n";
+        let res = fmt(source, cursor_before(source, "SENTINEL"));
+        assert_invariants(source, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    #[test]
+    fn cursor_maintained_on_emoji_heavy_line() {
+        let source = "Launch day 🎉 🚀 ✨ SENTINEL 🔥 shipped.\n";
+        let res = fmt(source, cursor_before(source, "SENTINEL"));
+        assert_invariants(source, &res);
+        assert_cursor_at_anchor(&res, "SENTINEL");
+    }
+
+    // ── Degenerate / tiny inputs ────────────────────────────────────
+
+    #[test]
+    fn whitespace_only_source_formats() {
+        let source = "   \n\n   \n";
+        let res = fmt(source, 0);
+        assert_invariants(source, &res);
+    }
+
+    #[test]
+    fn single_character_source_formats() {
+        let source = "x";
+        let res = fmt(source, count_utf16(source) as u32);
+        assert_invariants(source, &res);
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        assert!(res.formatted[..byte].ends_with('x'));
+    }
+
+    #[test]
+    fn cursor_at_end_of_multiline_document() {
+        let source = "= Heading\n\nA body paragraph that ends the document here.";
+        let res = fmt(source, count_utf16(source) as u32);
+        assert_invariants(source, &res);
+        let byte = utf16_to_byte_offset(&res.formatted, res.cursor as usize).unwrap();
+        assert!(
+            res.formatted[..byte].trim_end().ends_with("here."),
+            "cursor should follow the final sentence; got prefix tail {:?}",
+            res.formatted[..byte].chars().rev().take(12).collect::<String>()
+        );
+    }
 }
 
 /// Recursively collect every `.typ` file under `dir`, skipping hidden

--- a/apps/typwriter-desktop/src-tauri/src/commands/settings.rs
+++ b/apps/typwriter-desktop/src-tauri/src/commands/settings.rs
@@ -26,6 +26,11 @@ const ANDROID_FONTS_SUBDIR: &str = "Fonts";
 const STORE_FILE: &str = "app_data.json";
 const KEY_FONT_DIRECTORIES: &str = "settings.font_directories";
 const KEY_UI_SETTINGS: &str = "settings.ui";
+/// Whether the onboarding tutorial has been shown (completed OR skipped).
+/// Stored under its own key — deliberately *not* part of `AppSettings` — so the
+/// Settings page round-tripping the whole struct through `set_app_settings`
+/// can't accidentally reset it via serde defaults.
+const KEY_ONBOARDING_COMPLETED: &str = "settings.onboarding_completed";
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(default)]
@@ -149,6 +154,30 @@ pub fn load_font_directories(handle: &AppHandle) -> Vec<PathBuf> {
 #[tauri::command]
 pub fn get_app_settings(handle: AppHandle) -> AppSettings {
     read_settings(&handle)
+}
+
+#[tauri::command]
+pub fn get_onboarding_completed(handle: AppHandle) -> bool {
+    let Ok(store) = handle.store(STORE_FILE) else {
+        warn!("settings: could not open {STORE_FILE}");
+        return false;
+    };
+    store
+        .get(KEY_ONBOARDING_COMPLETED)
+        .and_then(|v: JsonValue| serde_json::from_value(v).ok())
+        .unwrap_or(false)
+}
+
+#[tauri::command]
+pub fn set_onboarding_completed(handle: AppHandle, completed: bool) {
+    let Ok(store) = handle.store(STORE_FILE) else {
+        warn!("settings: could not open {STORE_FILE}");
+        return;
+    };
+    store.set(KEY_ONBOARDING_COMPLETED, json!(completed));
+    if let Err(err) = store.save() {
+        warn!("settings: failed to save store: {err}");
+    }
 }
 
 #[tauri::command]

--- a/apps/typwriter-desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/typwriter-desktop/src-tauri/src/commands/workspace.rs
@@ -304,6 +304,12 @@ pub fn import_files_from_uris(
         );
     }
 
+    let count = sources.len();
+    workspace.snapshot_file_op(&format!(
+        "Imported {count} file{}",
+        if count == 1 { "" } else { "s" }
+    ));
+
     info!(
         "import_files_from_uris: ok ({:.1}ms)",
         t.elapsed().as_secs_f64() * 1000.0

--- a/apps/typwriter-desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/typwriter-desktop/src-tauri/src/commands/workspace.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf, sync::Arc, time::Instant};
+use std::{collections::HashMap, fs, path::PathBuf, sync::Arc, time::Instant};
 
 use log::{error, info};
 use serde::Serialize;
@@ -345,16 +345,17 @@ pub fn clear_recent_workspaces(workspace: State<'_, Arc<WorkspaceState>>) {
 pub fn save_workspace_tabs(
     tabs: Vec<String>,
     active_tab_id: Option<String>,
+    unsaved: HashMap<String, String>,
     workspace: State<'_, Arc<WorkspaceState>>,
 ) {
-    workspace.save_workspace_tabs(tabs, active_tab_id);
+    workspace.save_workspace_tabs(tabs, active_tab_id, unsaved);
 }
 
 #[tauri::command]
 pub fn get_workspace_tabs(
     root: String,
     workspace: State<'_, Arc<WorkspaceState>>,
-) -> Option<(Vec<String>, Option<String>)> {
+) -> Option<(Vec<String>, Option<String>, HashMap<String, String>)> {
     workspace.get_workspace_tabs(&root)
 }
 

--- a/apps/typwriter-desktop/src-tauri/src/compiler/disk_cache.rs
+++ b/apps/typwriter-desktop/src-tauri/src/compiler/disk_cache.rs
@@ -30,6 +30,7 @@ use std::{
 
 use log::{info, warn};
 use lru::LruCache;
+use serde::{Deserialize, Serialize};
 
 use super::cache::{key_to_path, parse_key, PageCacheKey};
 
@@ -178,6 +179,70 @@ impl DiskCache {
 
 fn file_path(dir: &Path, key: PageCacheKey) -> PathBuf {
     dir.join(format!("{}.png", key_to_path(key)))
+}
+
+// ─── Preview manifest ──────────────────────────────────────────────────────
+//
+// The disk cache stores PNG bytes keyed by `(fingerprint, zoom)`, but nothing
+// records which fingerprints, in what order, made up the last preview — and
+// you can't know that without compiling first. The manifest closes that gap: a
+// tiny JSON file listing the page keys (in page order) of the last successful
+// compile, tagged with the main file it belongs to. On open we can paint those
+// cached pages immediately, before the (font-blocked) compile produces fresh
+// fingerprints, then let the normal diff reconcile.
+
+/// Ordered page keys of the last successful preview. `pages[i]` is the cache
+/// key for page `i` (`None` if that page failed to render), encoded as the same
+/// `<hex>-<zoom>` string used by the `previewimg://` URL.
+#[derive(Serialize, Deserialize)]
+struct PreviewManifest {
+    main: String,
+    pages: Vec<Option<String>>,
+}
+
+fn manifest_path(root: &Path) -> PathBuf {
+    root.join(".typwriter")
+        .join("cache")
+        .join("preview-manifest.json")
+}
+
+/// Persist the ordered page keys of the current preview, tagged with `main`
+/// (the workspace-relative main file path). Best-effort: failures are logged
+/// and otherwise ignored.
+pub fn write_manifest(root: &Path, main: &str, pages: &[Option<PageCacheKey>]) {
+    let manifest = PreviewManifest {
+        main: main.to_string(),
+        pages: pages
+            .iter()
+            .map(|slot| slot.map(key_to_path))
+            .collect(),
+    };
+    let path = manifest_path(root);
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    match serde_json::to_vec(&manifest) {
+        Ok(bytes) => {
+            if let Err(err) = fs::write(&path, bytes) {
+                warn!("write_manifest: write failed path={path:?} err=\"{err}\"");
+            }
+        }
+        Err(err) => warn!("write_manifest: serialize failed err=\"{err}\""),
+    }
+}
+
+/// Read the persisted preview manifest. Returns `(main, pages)` where `pages[i]`
+/// is the cache key for page `i` (or `None`). `None` when no manifest exists or
+/// it can't be parsed.
+pub fn read_manifest(root: &Path) -> Option<(String, Vec<Option<PageCacheKey>>)> {
+    let bytes = fs::read(manifest_path(root)).ok()?;
+    let manifest: PreviewManifest = serde_json::from_slice(&bytes).ok()?;
+    let pages = manifest
+        .pages
+        .iter()
+        .map(|slot| slot.as_deref().and_then(parse_key))
+        .collect();
+    Some((manifest.main, pages))
 }
 
 impl Default for DiskCache {

--- a/apps/typwriter-desktop/src-tauri/src/compiler/mod.rs
+++ b/apps/typwriter-desktop/src-tauri/src/compiler/mod.rs
@@ -42,7 +42,7 @@ use crate::workspace::WorkspaceState;
 use crate::world::EditorWorld;
 use cache::PageCache;
 use disk_cache::DiskCache;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use typst::layout::PagedDocument;
 
 // IPC payloads
@@ -238,6 +238,10 @@ pub struct PreviewPipeline {
     /// Lookups fall through to disk on in-memory LRU misses, and renders write
     /// to both layers so subsequent app sessions skip re-rendering.
     disk_cache: Mutex<Option<DiskCache>>,
+    /// Workspace root of the attached disk cache. Held so the preview manifest
+    /// (which lives alongside the cached PNGs) can be read/written without
+    /// threading the path through every call.
+    workspace_root: Mutex<Option<PathBuf>>,
     // The most recently successfully compiled document.
     // Held so IDE features (hover, go-to-def, jump-from-click) can use it.
     pub last_document: Mutex<Option<Arc<PagedDocument>>>,
@@ -264,6 +268,7 @@ impl PreviewPipeline {
             last_emitted: Mutex::new(Vec::new()),
             page_cache: Mutex::new(PageCache::default()),
             disk_cache: Mutex::new(None),
+            workspace_root: Mutex::new(None),
             last_document: Mutex::new(None),
             app_handle,
             zoom: Mutex::new(2.0),
@@ -304,6 +309,61 @@ impl PreviewPipeline {
     pub fn attach_disk_cache(&self, workspace_root: &Path) {
         let cache = disk_cache::open_default(workspace_root);
         *self.disk_cache.lock() = Some(cache);
+        *self.workspace_root.lock() = Some(workspace_root.to_path_buf());
+    }
+
+    /// Paint the previously-rendered preview from disk *before* the next compile
+    /// runs. Reads the manifest written by the last successful compile; if it's
+    /// for `main_rel` and its pages still have bytes on disk, emits them and
+    /// seeds `last_emitted` so the subsequent (font-blocked) compile reconciles
+    /// via the normal diff instead of re-emitting unchanged pages.
+    ///
+    /// This is what lets a re-opened workspace show its preview immediately
+    /// while fonts load and the document recompiles in the background.
+    pub fn restore_preview(&self, main_rel: &str) {
+        let Some(root) = self.workspace_root.lock().clone() else {
+            return;
+        };
+        let Some((manifest_main, pages)) = disk_cache::read_manifest(&root) else {
+            return;
+        };
+        if manifest_main != main_rel || pages.is_empty() {
+            return;
+        }
+
+        let count = pages.len();
+        let mut emitted: Vec<Option<PageCacheKey>> = vec![None; count];
+        let mut painted = 0usize;
+        {
+            let mut disk = self.disk_cache.lock();
+            let Some(disk) = disk.as_mut() else {
+                return;
+            };
+            let _ = self
+                .app_handle
+                .emit("preview:total-pages", TotalPagesPayload { count });
+            for (idx, slot) in pages.iter().enumerate() {
+                let Some(key) = slot else { continue };
+                if !disk.contains(*key) {
+                    continue;
+                }
+                let _ = self.app_handle.emit(
+                    "preview:page-updated",
+                    PageUpdatedPayload {
+                        index: idx,
+                        fingerprint: key_to_path(*key),
+                    },
+                );
+                emitted[idx] = Some(*key);
+                painted += 1;
+            }
+        }
+
+        if painted == 0 {
+            return;
+        }
+        *self.last_emitted.lock() = emitted;
+        info!("restore_preview: painted {painted}/{count} cached page(s) for main={main_rel:?}");
     }
 
     /// Re-emit total-pages and every previously-emitted page key. Used when a
@@ -451,6 +511,15 @@ impl PreviewPipeline {
             }
             return;
         }
+
+        // Fonts load lazily (first workspace open). Make sure the search has
+        // been kicked off and block until a font set is installed — compiling
+        // against the empty fallback book would render fonts-less pages and
+        // cache them to disk. The wait is usually already satisfied because the
+        // search was started at workspace-open time and overlapped the rest of
+        // the open path.
+        self.world.ensure_fonts_loading();
+        self.world.wait_until_fonts_loaded();
 
         let CompileOutput {
             document,
@@ -675,6 +744,16 @@ impl PreviewPipeline {
                     },
                 );
                 new_emitted[idx] = Some(key);
+            }
+        }
+
+        // Persist the page manifest (best effort) so the next open can paint
+        // this preview from disk before the font-blocked recompile finishes.
+        if new_emitted.iter().any(Option::is_some) {
+            if let (Some(root), Some(main_rel)) =
+                (self.workspace_root.lock().clone(), self.world.main_rel())
+            {
+                disk_cache::write_manifest(&root, &main_rel, &new_emitted);
             }
         }
 

--- a/apps/typwriter-desktop/src-tauri/src/lib.rs
+++ b/apps/typwriter-desktop/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use workspace::WorkspaceState;
 use world::EditorWorld;
 
 use commands::{
-    app::is_fonts_loaded,
+    app::{is_fonts_loaded, prepare_onboarding_workspace},
     click::{jump_from_click, jump_from_cursor},
     editor::{
         discard_shadow, get_completions, get_definitions, get_tooltip, read_file, save_file,
@@ -36,8 +36,8 @@ use commands::{
     logs::get_log_file_path,
     preview::{get_zoom, set_visible_page, set_zoom, sync_preview, trigger_preview},
     settings::{
-        get_app_settings, import_font_directory_uri, list_font_families, set_app_settings,
-        set_typst_font_directories,
+        get_app_settings, get_onboarding_completed, import_font_directory_uri, list_font_families,
+        set_app_settings, set_onboarding_completed, set_typst_font_directories,
     },
     vcs::{
         vcs_create_restore_point, vcs_current_id, vcs_diff_between, vcs_diff_vs_current,
@@ -184,6 +184,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             // app init
             is_fonts_loaded,
+            prepare_onboarding_workspace,
             // workspace / file-system
             open_folder,
             create_workspace,
@@ -230,6 +231,8 @@ pub fn run() {
             // settings
             get_app_settings,
             set_app_settings,
+            get_onboarding_completed,
+            set_onboarding_completed,
             list_font_families,
             set_typst_font_directories,
             import_font_directory_uri,

--- a/apps/typwriter-desktop/src-tauri/src/lib.rs
+++ b/apps/typwriter-desktop/src-tauri/src/lib.rs
@@ -128,6 +128,27 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_opener::init())
+        .on_window_event(|window, event| {
+            // The preview pane can be popped out into its own `preview` window.
+            // It outlives the main window (and keeps the process alive), so
+            // closing the main window would otherwise leave it orphaned on
+            // screen. Tear it down whenever the main window goes away — handled
+            // here in Rust so it fires on every close path, not just the ones
+            // where the frontend gets to run its cleanup.
+            if window.label() == "main"
+                && matches!(
+                    event,
+                    tauri::WindowEvent::CloseRequested { .. } | tauri::WindowEvent::Destroyed
+                )
+            {
+                if let Some(preview) = window.app_handle().get_webview_window("preview") {
+                    // `destroy` rather than `close`: a forced teardown that the
+                    // preview window's own JS can't prevent, so the orphan is
+                    // guaranteed to go away.
+                    let _ = preview.destroy();
+                }
+            }
+        })
         .setup(|app| {
             let handle = app.handle().clone();
 

--- a/apps/typwriter-desktop/src-tauri/src/lib.rs
+++ b/apps/typwriter-desktop/src-tauri/src/lib.rs
@@ -153,8 +153,12 @@ pub fn run() {
             let root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
 
             // ── Shared state (managed immediately — fonts arrive later) ──────
-            let world = Arc::new(EditorWorld::new(root, handle.clone()));
+            // `vcs` is constructed first: it owns the SAF-root registry and the
+            // `WorkingTreeFs` provider the world reads source files through, so
+            // a folder picked via Android's Storage Access Framework is fully
+            // usable (open / edit / compile), not just listable.
             let vcs = Arc::new(VcsState::new(handle.clone()));
+            let world = Arc::new(EditorWorld::new(root, handle.clone(), vcs.clone()));
             let pipeline = Arc::new(PreviewPipeline::new(
                 world.clone(),
                 handle.clone(),

--- a/apps/typwriter-desktop/src-tauri/src/lib.rs
+++ b/apps/typwriter-desktop/src-tauri/src/lib.rs
@@ -128,6 +128,10 @@ pub fn run() {
             // screen. Tear it down whenever the main window goes away — handled
             // here in Rust so it fires on every close path, not just the ones
             // where the frontend gets to run its cleanup.
+            // The preview popout is desktop-only (mobile has no multi-window),
+            // and `WebviewWindow::destroy` is itself a desktop-only API, so the
+            // whole teardown is gated behind `#[cfg(desktop)]`.
+            #[cfg(desktop)]
             if window.label() == "main"
                 && matches!(
                     event,

--- a/apps/typwriter-desktop/src-tauri/src/lib.rs
+++ b/apps/typwriter-desktop/src-tauri/src/lib.rs
@@ -6,14 +6,12 @@ mod vcs;
 mod workspace;
 mod world;
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use compiler::{parse_key, PreviewPipeline};
 use parking_lot::RwLock;
-use tauri::{Emitter, Manager};
+use tauri::Manager;
 use tauri_plugin_log::{RotationStrategy, Target, TargetKind};
-use typst_kit::fonts::FontSearcher;
 use vcs::VcsState;
 use workspace::WorkspaceState;
 use world::EditorWorld;
@@ -52,11 +50,6 @@ use commands::{
         set_main_file,
     },
 };
-
-/// Lightweight state managed immediately so the frontend can query readiness.
-pub struct AppInit {
-    pub fonts_loaded: AtomicBool,
-}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -156,9 +149,6 @@ pub fn run() {
             let root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
 
             // ── Shared state (managed immediately — fonts arrive later) ──────
-            let init = Arc::new(AppInit {
-                fonts_loaded: AtomicBool::new(false),
-            });
             let world = Arc::new(EditorWorld::new(root, handle.clone()));
             let vcs = Arc::new(VcsState::new(handle.clone()));
             let pipeline = Arc::new(PreviewPipeline::new(
@@ -181,24 +171,16 @@ pub fn run() {
                 commands::settings::snapshot_policy_from_handle(&handle),
             ));
 
-            app.manage(init.clone());
             app.manage(world.clone());
             app.manage(pipeline);
             app.manage(workspace);
             app.manage(vcs);
             app.manage(snapshot_policy);
 
-            // ── Background font loading ─────────────────────────────────────
-            // Pick up any extra font directories the user configured in a
-            // previous session so their custom fonts are available from the
-            // first compile.
-            let extra_font_dirs = commands::settings::load_font_directories(&handle);
-            std::thread::spawn(move || {
-                let font_results = FontSearcher::new().search_with(&extra_font_dirs);
-                world.load_fonts(font_results.book, font_results.fonts);
-                init.fonts_loaded.store(true, Ordering::Release);
-                let _ = handle.emit("app:fonts-loaded", ());
-            });
+            // Fonts are loaded lazily: the first workspace open (and, as a
+            // safety net, the first compile) calls `EditorWorld::ensure_fonts_loading`,
+            // so the system font scan overlaps the rest of the open path instead
+            // of blocking startup. See `world::mod`.
 
             Ok(())
         })

--- a/apps/typwriter-desktop/src-tauri/src/vcs/commit.rs
+++ b/apps/typwriter-desktop/src-tauri/src/vcs/commit.rs
@@ -35,6 +35,9 @@ pub enum CommitTrigger {
     Compile,
     /// Snapshot of working state captured before restoring (safety net).
     PreRestore,
+    /// Triggered by a structural file operation (create / delete / rename /
+    /// move / import) so the change can be undone from the timeline.
+    FileOp,
 }
 
 impl CommitTrigger {
@@ -45,15 +48,21 @@ impl CommitTrigger {
             CommitTrigger::Save => "save",
             CommitTrigger::Compile => "compile",
             CommitTrigger::PreRestore => "pre-restore",
+            CommitTrigger::FileOp => "file-op",
         }
     }
 
-    /// Manual / Initial / PreRestore snapshots are user-driven or
-    /// safety-critical — they never get pruned by retention rules.
+    /// Manual / Initial / PreRestore / FileOp snapshots are user-driven or
+    /// safety-critical — they never get pruned by retention rules. FileOp
+    /// points record structural changes (delete / rename / move) and are the
+    /// recovery anchor for them, so they must survive aggressive retention.
     pub fn is_preserved(self) -> bool {
         matches!(
             self,
-            CommitTrigger::Manual | CommitTrigger::Initial | CommitTrigger::PreRestore
+            CommitTrigger::Manual
+                | CommitTrigger::Initial
+                | CommitTrigger::PreRestore
+                | CommitTrigger::FileOp
         )
     }
 }

--- a/apps/typwriter-desktop/src-tauri/src/vcs/fs.rs
+++ b/apps/typwriter-desktop/src-tauri/src/vcs/fs.rs
@@ -18,6 +18,57 @@ pub trait WorkingTreeFs {
     fn remove_file(&self, path: &Path) -> Result<(), String>;
     fn remove_dir(&self, path: &Path) -> Result<(), String>;
     fn exists(&self, path: &Path) -> bool;
+
+    /// Recursively delete a directory and everything beneath it. The default
+    /// walks the tree with the other primitives so it works over SAF;
+    /// [`LocalWorkingTreeFs`] overrides it with `std::fs::remove_dir_all`.
+    fn remove_dir_all(&self, path: &Path) -> Result<(), String> {
+        for entry in self.read_dir(path)? {
+            if entry.is_dir {
+                self.remove_dir_all(&entry.path)?;
+            } else {
+                self.remove_file(&entry.path)?;
+            }
+        }
+        self.remove_dir(path)
+    }
+
+    /// Move/rename a file or directory. The Storage Access Framework has no
+    /// atomic rename across the document tree, so the default copies then
+    /// deletes; [`LocalWorkingTreeFs`] overrides it with the atomic
+    /// `std::fs::rename`.
+    fn rename(&self, from: &Path, to: &Path) -> Result<(), String> {
+        self.copy_tree(from, to)?;
+        self.remove_tree(from)
+    }
+
+    /// Recursively copy a file or directory. A successful `read_dir` means
+    /// `from` is a directory; otherwise it is treated as a file. Backs the
+    /// default [`rename`](Self::rename).
+    fn copy_tree(&self, from: &Path, to: &Path) -> Result<(), String> {
+        match self.read_dir(from) {
+            Ok(entries) => {
+                self.create_dir_all(to)?;
+                for entry in entries {
+                    self.copy_tree(&entry.path, &to.join(&entry.name))?;
+                }
+                Ok(())
+            }
+            Err(_) => {
+                let bytes = self.read_file(from)?;
+                self.write_file(to, &bytes)
+            }
+        }
+    }
+
+    /// Recursively delete a file or directory. Companion to
+    /// [`copy_tree`](Self::copy_tree) for the default [`rename`](Self::rename).
+    fn remove_tree(&self, path: &Path) -> Result<(), String> {
+        match self.read_dir(path) {
+            Ok(_) => self.remove_dir_all(path),
+            Err(_) => self.remove_file(path),
+        }
+    }
 }
 
 pub struct LocalWorkingTreeFs;
@@ -66,6 +117,14 @@ impl WorkingTreeFs for LocalWorkingTreeFs {
 
     fn exists(&self, path: &Path) -> bool {
         path.exists()
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> Result<(), String> {
+        fs::remove_dir_all(path).map_err(|e| format!("remove_dir_all {path:?}: {e}"))
+    }
+
+    fn rename(&self, from: &Path, to: &Path) -> Result<(), String> {
+        fs::rename(from, to).map_err(|e| format!("rename {from:?} -> {to:?}: {e}"))
     }
 }
 

--- a/apps/typwriter-desktop/src-tauri/src/vcs/mod.rs
+++ b/apps/typwriter-desktop/src-tauri/src/vcs/mod.rs
@@ -54,8 +54,8 @@ use std::time::Instant;
 use log::{info, warn};
 use parking_lot::{Mutex, RwLock};
 
-#[cfg(not(target_os = "android"))]
 use fs::LocalWorkingTreeFs;
+pub use fs::WorkingTreeFs;
 
 /// User preferences governing automatic snapshot creation. Lives behind an
 /// `Arc<RwLock<_>>` managed by Tauri; refreshed whenever the frontend
@@ -188,6 +188,45 @@ impl VcsState {
 
     fn workspace_root(&self) -> Option<PathBuf> {
         self.root.read().clone()
+    }
+
+    /// Build a filesystem accessor for *reading* the working tree at `root`
+    /// (e.g. the sidebar file tree). On Android a SAF-picked folder lives behind
+    /// the Storage Access Framework and is invisible to `std::fs` — the app holds
+    /// no broad storage permission — so it must be read through android-fs. The
+    /// auto-managed, app-scoped workspaces dir is reachable with `std::fs`
+    /// directly, and so is every desktop path. Mirrors how snapshots read the
+    /// working tree, keeping the file tree and version history in lockstep.
+    pub fn working_tree_fs_for(&self, root: &Path) -> Box<dyn WorkingTreeFs> {
+        #[cfg(target_os = "android")]
+        {
+            if let Some(uri) = self.saf_roots.read().get(root).cloned() {
+                return Box::new(fs::AndroidWorkingTreeFs::new_with_root(
+                    self.app_handle.clone(),
+                    root.to_path_buf(),
+                    uri,
+                ));
+            }
+        }
+        let _ = root;
+        Box::new(LocalWorkingTreeFs)
+    }
+
+    /// Whether `root` is a folder picked through Android's Storage Access
+    /// Framework — i.e. one that `std::fs` (and the `convertFileSrc` asset
+    /// protocol) cannot reach. Always `false` off Android. Callers use this to
+    /// decide when to ship file bytes inline instead of handing the frontend a
+    /// std::fs path.
+    pub fn is_saf_root(&self, root: &Path) -> bool {
+        #[cfg(target_os = "android")]
+        {
+            return self.saf_roots.read().contains_key(root);
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            let _ = root;
+            false
+        }
     }
 
     #[cfg(target_os = "android")]

--- a/apps/typwriter-desktop/src-tauri/src/vcs/mod.rs
+++ b/apps/typwriter-desktop/src-tauri/src/vcs/mod.rs
@@ -93,13 +93,16 @@ impl SnapshotPolicy {
     }
 
     /// Does this trigger fall under the auto-snapshot gate? Manual / Initial
-    /// / PreRestore always bypass — those are user-driven or safety-critical
-    /// and never throttled by user prefs.
+    /// / PreRestore / FileOp always bypass — those are user-driven or
+    /// safety-critical and never throttled by user prefs.
     pub fn allows(&self, trigger: CommitTrigger) -> bool {
         match trigger {
             CommitTrigger::Save => self.on_save,
             CommitTrigger::Compile => self.on_compile,
-            CommitTrigger::Manual | CommitTrigger::Initial | CommitTrigger::PreRestore => true,
+            CommitTrigger::Manual
+            | CommitTrigger::Initial
+            | CommitTrigger::PreRestore
+            | CommitTrigger::FileOp => true,
         }
     }
 }

--- a/apps/typwriter-desktop/src-tauri/src/workspace/mod.rs
+++ b/apps/typwriter-desktop/src-tauri/src/workspace/mod.rs
@@ -17,6 +17,7 @@ mod watcher;
 use log::{error, info, warn};
 use parking_lot::{Mutex, RwLock};
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, Instant},
@@ -348,15 +349,23 @@ impl WorkspaceState {
 
     // ─── Open tabs persistence ──────────────────────────────────────────────
 
-    pub fn save_workspace_tabs(&self, tabs: Vec<String>, active_tab_id: Option<String>) {
+    pub fn save_workspace_tabs(
+        &self,
+        tabs: Vec<String>,
+        active_tab_id: Option<String>,
+        unsaved: HashMap<String, String>,
+    ) {
         let root = self.root.read();
         let Some(root) = root.as_ref() else {
             return;
         };
-        store::save_workspace_tabs(&self.app_handle, root, tabs, active_tab_id);
+        store::save_workspace_tabs(&self.app_handle, root, tabs, active_tab_id, unsaved);
     }
 
-    pub fn get_workspace_tabs(&self, root: &str) -> Option<(Vec<String>, Option<String>)> {
+    pub fn get_workspace_tabs(
+        &self,
+        root: &str,
+    ) -> Option<(Vec<String>, Option<String>, HashMap<String, String>)> {
         store::get_workspace_tabs(&self.app_handle, &PathBuf::from(root))
     }
 

--- a/apps/typwriter-desktop/src-tauri/src/workspace/mod.rs
+++ b/apps/typwriter-desktop/src-tauri/src/workspace/mod.rs
@@ -31,7 +31,7 @@ use typst::syntax::{FileId, VirtualPath};
 
 use crate::{
     compiler::{render_page, CompileReason, PreviewPipeline},
-    vcs::{CommitTrigger, VcsState},
+    vcs::{CommitTrigger, VcsState, WorkingTreeFs},
     world::EditorWorld,
 };
 use path::{ExternalPath, WorkspacePath};
@@ -388,6 +388,16 @@ impl WorkspaceState {
             .map_err(|e| e.to_string())
     }
 
+    /// SAF-aware filesystem accessor for the current workspace root. Every
+    /// structural file op routes its disk work through this so a folder picked
+    /// via Android's Storage Access Framework (unreachable with `std::fs`) is
+    /// mutable, not just listable. Off Android / for the managed dir this is a
+    /// plain std::fs accessor.
+    fn working_fs(&self) -> Result<Box<dyn WorkingTreeFs>, String> {
+        let root = self.root.read().clone().ok_or("No workspace open")?;
+        Ok(self.vcs.working_tree_fs_for(&root))
+    }
+
     /// Capture a restore point recording a structural file operation so it can
     /// be undone from the timeline. File operations are user-intentional and
     /// infrequent, so they always snapshot (no save/compile policy gate) and
@@ -418,18 +428,19 @@ impl WorkspaceState {
     pub fn create_file(&self, path: &str) -> Result<(), String> {
         let t = Instant::now();
         let abs = self.resolve(path)?;
+        let fs = self.working_fs()?;
         info!("WorkspaceState::create_file: abs={abs:?}");
         if let Some(parent) = abs.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| {
+            fs.create_dir_all(parent).map_err(|e| {
                 error!(
                     "WorkspaceState::create_file: create_dir_all failed abs={abs:?} err=\"{e}\""
                 );
-                e.to_string()
+                e
             })?;
         }
-        std::fs::File::create(&abs).map_err(|e| {
+        fs.write_file(&abs, b"").map_err(|e| {
             error!("WorkspaceState::create_file: create failed abs={abs:?} err=\"{e}\"");
-            e.to_string()
+            e
         })?;
         self.snapshot_file_op(&format!("Created {}", basename(path)));
         info!(
@@ -444,9 +455,9 @@ impl WorkspaceState {
         let t = Instant::now();
         let abs = self.resolve(path)?;
         info!("WorkspaceState::create_folder: abs={abs:?}");
-        std::fs::create_dir_all(&abs).map_err(|e| {
+        self.working_fs()?.create_dir_all(&abs).map_err(|e| {
             error!("WorkspaceState::create_folder: failed abs={abs:?} err=\"{e}\"");
-            e.to_string()
+            e
         })?;
         // Empty directories aren't tracked by the content-addressed store, so
         // this is typically a no-op; kept for uniformity across file ops.
@@ -463,9 +474,9 @@ impl WorkspaceState {
         let t = Instant::now();
         let abs = self.resolve(path)?;
         info!("WorkspaceState::delete_file: abs={abs:?}");
-        std::fs::remove_file(&abs).map_err(|e| {
+        self.working_fs()?.remove_file(&abs).map_err(|e| {
             error!("WorkspaceState::delete_file: failed abs={abs:?} err=\"{e}\"");
-            e.to_string()
+            e
         })?;
         if let Some(id) = self.world.path_to_id(&abs) {
             self.world.shadow_remove(id);
@@ -493,16 +504,17 @@ impl WorkspaceState {
         let t = Instant::now();
         let src_abs = self.resolve(src)?;
         let dst_abs = self.resolve(dst)?;
+        let fs = self.working_fs()?;
         info!("WorkspaceState::rename_file: src={src_abs:?} dst={dst_abs:?}");
         if let Some(parent) = dst_abs.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| {
+            fs.create_dir_all(parent).map_err(|e| {
                 error!("WorkspaceState::rename_file: create_dir_all failed dst_parent={parent:?} err=\"{e}\"");
-                e.to_string()
+                e
             })?;
         }
-        std::fs::rename(&src_abs, &dst_abs).map_err(|e| {
+        fs.rename(&src_abs, &dst_abs).map_err(|e| {
             error!("WorkspaceState::rename_file: rename failed src={src_abs:?} dst={dst_abs:?} err=\"{e}\"");
-            e.to_string()
+            e
         })?;
         // Invalidate old id; new id will be cached on next access.
         if let Some(id) = self.world.path_to_id(&src_abs) {
@@ -529,26 +541,28 @@ impl WorkspaceState {
     pub fn delete_folder(&self, path: &str) -> Result<(), String> {
         let t = Instant::now();
         let abs = self.resolve(path)?;
+        let fs = self.working_fs()?;
         info!("WorkspaceState::delete_folder: abs={abs:?}");
 
         // Invalidate caches for every file inside the directory before removing.
-        if abs.is_dir() {
-            let files = collect_files_recursive(&abs);
-            info!(
-                "WorkspaceState::delete_folder: invalidating {} cached file(s)",
-                files.len()
-            );
-            for file_path in files {
-                if let Some(id) = self.world.path_to_id(&file_path) {
-                    self.world.shadow_remove(id);
-                    self.world.invalidate_file(id);
-                }
+        // `collect_files_recursive` returns empty for a non-directory (or a SAF
+        // path std::fs can't see), so the cache walk goes through the accessor
+        // too — `is_dir()` would always be false for a SAF folder.
+        let files = collect_files_recursive(fs.as_ref(), &abs);
+        info!(
+            "WorkspaceState::delete_folder: invalidating {} cached file(s)",
+            files.len()
+        );
+        for file_path in files {
+            if let Some(id) = self.world.path_to_id(&file_path) {
+                self.world.shadow_remove(id);
+                self.world.invalidate_file(id);
             }
         }
 
-        std::fs::remove_dir_all(&abs).map_err(|e| {
+        fs.remove_dir_all(&abs).map_err(|e| {
             error!("WorkspaceState::delete_folder: failed abs={abs:?} err=\"{e}\"");
-            e.to_string()
+            e
         })?;
         if self
             .main_file
@@ -577,12 +591,15 @@ impl WorkspaceState {
     pub fn import_files(&self, sources: &[String], dest_dir: &str) -> Result<(), String> {
         let t = Instant::now();
         let dest = self.resolve(dest_dir)?;
+        let fs = self.working_fs()?;
         info!(
             "WorkspaceState::import_files: dest={dest:?} count={}",
             sources.len()
         );
 
-        if !dest.is_dir() {
+        // A readable directory listing confirms `dest` exists and is a folder.
+        // `dest.is_dir()` (std::fs) would wrongly report `false` for a SAF root.
+        if fs.read_dir(&dest).is_err() {
             let e = format!("{} is not a directory", dest.display());
             error!("WorkspaceState::import_files: err=\"{e}\"");
             return Err(e);
@@ -590,6 +607,9 @@ impl WorkspaceState {
 
         for src_str in sources {
             let src_path = ExternalPath::new(src_str).map_err(|e| e.to_string())?;
+            // Source files come from a system picker / external location and are
+            // read with std::fs; only the destination (inside the workspace) may
+            // sit behind SAF, so the write goes through the accessor.
             if !src_path.as_path().is_file() {
                 let e = format!("Source is not a file: {}", src_path.as_path().display());
                 error!("WorkspaceState::import_files: err=\"{e}\"");
@@ -604,14 +624,18 @@ impl WorkspaceState {
                 e
             })?;
             let dst_path = dest.join(file_name);
-            if dst_path.exists() {
+            if fs.exists(&dst_path) {
                 let e = format!("File already exists: {}", dst_path.display());
                 error!("WorkspaceState::import_files: err=\"{e}\"");
                 return Err(e);
             }
-            std::fs::copy(src_path.as_path(), &dst_path).map_err(|e| {
-                error!("WorkspaceState::import_files: copy failed src={src_path:?} dst={dst_path:?} err=\"{e}\"");
+            let bytes = std::fs::read(src_path.as_path()).map_err(|e| {
+                error!("WorkspaceState::import_files: read failed src={src_path:?} err=\"{e}\"");
                 e.to_string()
+            })?;
+            fs.write_file(&dst_path, &bytes).map_err(|e| {
+                error!("WorkspaceState::import_files: write failed dst={dst_path:?} err=\"{e}\"");
+                e
             })?;
             info!(
                 "WorkspaceState::import_files: copied {:?} -> {:?}",
@@ -637,18 +661,19 @@ impl WorkspaceState {
         let t = Instant::now();
         let src_abs = self.resolve(src)?;
         let dst_abs = self.resolve(dst)?;
+        let fs = self.working_fs()?;
         info!("WorkspaceState::move_folder: src={src_abs:?} dst={dst_abs:?}");
         if let Some(parent) = dst_abs.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| {
+            fs.create_dir_all(parent).map_err(|e| {
                 error!("WorkspaceState::move_folder: create_dir_all failed dst_parent={parent:?} err=\"{e}\"");
-                e.to_string()
+                e
             })?;
         }
-        std::fs::rename(&src_abs, &dst_abs).map_err(|e| {
+        fs.rename(&src_abs, &dst_abs).map_err(|e| {
             error!(
                 "WorkspaceState::move_folder: failed src={src_abs:?} dst={dst_abs:?} err=\"{e}\""
             );
-            e.to_string()
+            e
         })?;
         self.update_main_file_path(&src_abs, &dst_abs, true)?;
         let message = if dirname(src) == dirname(dst) {
@@ -679,7 +704,24 @@ impl WorkspaceState {
                 })?
                 .clone()
         };
-        Ok(read_dir_recursive(&root, &root))
+
+        // Read through the SAF-aware accessor: a folder picked via Android's
+        // Storage Access Framework is unreachable with std::fs (no broad storage
+        // permission), so we must list it through android-fs. The managed
+        // app-scoped dir and all desktop paths fall back to std::fs.
+        let fs = self.vcs.working_tree_fs_for(&root);
+
+        // Surface an unreadable root as an explicit error instead of silently
+        // returning an empty tree. A silent empty result is indistinguishable
+        // from a genuinely empty workspace, which is how an inaccessible root
+        // ends up looking like a workspace with no files. An empty-but-readable
+        // root is still a valid empty tree and returns Ok(vec![]).
+        fs.read_dir(&root).map_err(|e| {
+            error!("WorkspaceState::get_file_tree: cannot read root={root:?} err=\"{e}\"");
+            format!("Cannot read workspace folder {}: {e}", root.display())
+        })?;
+
+        Ok(read_dir_recursive(fs.as_ref(), &root, &root))
     }
 }
 
@@ -730,32 +772,39 @@ impl WorkspaceState {
 
 // ─── Directory reading ────────────────────────────────────────────────────────
 
-fn read_dir_recursive(root: &Path, dir: &Path) -> Vec<FileTreeEntry> {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        warn!("read_dir_recursive: failed to read dir={dir:?}");
-        return vec![];
+/// Directories never shown in the file tree and never descended into. Mirrors
+/// the watcher's ignore list (`watcher::IGNORED_DIRS`) so the tree walk doesn't
+/// spend time (and IPC payload) recursing through huge generated/dependency
+/// folders. Dot-prefixed names (`.git`, `.typwriter`, `.svelte-kit`) are already
+/// filtered separately; these are the non-dotfile cases.
+const IGNORED_TREE_DIRS: &[&str] = &["node_modules", "target", "dist"];
+
+fn read_dir_recursive(fs: &dyn WorkingTreeFs, root: &Path, dir: &Path) -> Vec<FileTreeEntry> {
+    let entries = match fs.read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            warn!("read_dir_recursive: failed to read dir={dir:?} err=\"{err}\"");
+            return vec![];
+        }
     };
 
     let mut result: Vec<FileTreeEntry> = entries
+        .into_iter()
         .filter_map(|entry| {
-            let entry = match entry {
-                Ok(entry) => entry,
-                Err(err) => {
-                    warn!("read_dir_recursive: skipped entry in dir={dir:?} err=\"{err}\"");
-                    return None;
-                }
-            };
-            let path = entry.path();
-            let name = path.file_name()?.to_str()?.to_string();
+            let name = entry.name;
             // Skip hidden files/dirs (e.g. .git).
             if name.starts_with('.') {
                 return None;
             }
-            let rel = path.strip_prefix(root).ok()?;
+            let is_dir = entry.is_dir;
+            // Don't surface or descend into generated/dependency directories.
+            if is_dir && IGNORED_TREE_DIRS.contains(&name.as_str()) {
+                return None;
+            }
+            let rel = entry.path.strip_prefix(root).ok()?;
             let path_str = rel.to_str()?.to_string();
-            let is_dir = path.is_dir();
             let children = if is_dir {
-                read_dir_recursive(root, &path)
+                read_dir_recursive(fs, root, &entry.path)
             } else {
                 vec![]
             };
@@ -778,27 +827,23 @@ fn read_dir_recursive(root: &Path, dir: &Path) -> Vec<FileTreeEntry> {
     result
 }
 
-/// Recursively collect all file paths under `dir`.
-fn collect_files_recursive(dir: &Path) -> Vec<PathBuf> {
+/// Recursively collect all file paths under `dir`, through the SAF-aware
+/// accessor so a folder picked via the Storage Access Framework is walked too.
+fn collect_files_recursive(fs: &dyn WorkingTreeFs, dir: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        warn!("collect_files_recursive: failed to read dir={dir:?}");
-        return files;
+    let entries = match fs.read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            warn!("collect_files_recursive: failed to read dir={dir:?} err=\"{err}\"");
+            return files;
+        }
     };
 
     for entry in entries {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(err) => {
-                warn!("collect_files_recursive: skipped entry in dir={dir:?} err=\"{err}\"");
-                continue;
-            }
-        };
-        let path = entry.path();
-        if path.is_dir() {
-            files.extend(collect_files_recursive(&path));
+        if entry.is_dir {
+            files.extend(collect_files_recursive(fs, &entry.path));
         } else {
-            files.push(path);
+            files.push(entry.path);
         }
     }
     files

--- a/apps/typwriter-desktop/src-tauri/src/workspace/mod.rs
+++ b/apps/typwriter-desktop/src-tauri/src/workspace/mod.rs
@@ -30,7 +30,7 @@ use typst::syntax::{FileId, VirtualPath};
 
 use crate::{
     compiler::{render_page, CompileReason, PreviewPipeline},
-    vcs::VcsState,
+    vcs::{CommitTrigger, VcsState},
     world::EditorWorld,
 };
 use path::{ExternalPath, WorkspacePath};
@@ -367,6 +367,30 @@ impl WorkspaceState {
             .map_err(|e| e.to_string())
     }
 
+    /// Capture a restore point recording a structural file operation so it can
+    /// be undone from the timeline. File operations are user-intentional and
+    /// infrequent, so they always snapshot (no save/compile policy gate) and
+    /// are preserved from retention. The snapshot is taken *after* the
+    /// operation, matching `save_file`: HEAD ends up matching disk, and the
+    /// recoverable prior state lives in the preceding restore point.
+    ///
+    /// Failures are logged and swallowed — versioning must never block file
+    /// management, mirroring the rest of the VCS integration.
+    pub(crate) fn snapshot_file_op(&self, message: &str) {
+        match self.vcs.commit_if_changed(CommitTrigger::FileOp, message) {
+            Ok(Some(id)) => {
+                let short = &id[..id.len().min(8)];
+                info!("WorkspaceState::snapshot_file_op: {short} — {message}");
+            }
+            Ok(None) => {
+                info!("WorkspaceState::snapshot_file_op: no change to snapshot — {message}");
+            }
+            Err(err) => {
+                warn!("WorkspaceState::snapshot_file_op: failed err=\"{err}\" — {message}");
+            }
+        }
+    }
+
     // ─── FS operations ─────────────────────────────────────────────────────
 
     /// Create an empty file at `path`.
@@ -386,6 +410,7 @@ impl WorkspaceState {
             error!("WorkspaceState::create_file: create failed abs={abs:?} err=\"{e}\"");
             e.to_string()
         })?;
+        self.snapshot_file_op(&format!("Created {}", basename(path)));
         info!(
             "WorkspaceState::create_file: ok ({:.1}ms)",
             t.elapsed().as_secs_f64() * 1000.0
@@ -402,6 +427,9 @@ impl WorkspaceState {
             error!("WorkspaceState::create_folder: failed abs={abs:?} err=\"{e}\"");
             e.to_string()
         })?;
+        // Empty directories aren't tracked by the content-addressed store, so
+        // this is typically a no-op; kept for uniformity across file ops.
+        self.snapshot_file_op(&format!("Created folder {}", basename(path)));
         info!(
             "WorkspaceState::create_folder: ok ({:.1}ms)",
             t.elapsed().as_secs_f64() * 1000.0
@@ -431,6 +459,7 @@ impl WorkspaceState {
         {
             self.clear_main_file();
         }
+        self.snapshot_file_op(&format!("Deleted {}", basename(path)));
         info!(
             "WorkspaceState::delete_file: ok ({:.1}ms)",
             t.elapsed().as_secs_f64() * 1000.0
@@ -460,6 +489,12 @@ impl WorkspaceState {
             self.world.invalidate_file(id);
         }
         self.update_main_file_path(&src_abs, &dst_abs, false)?;
+        let message = if dirname(src) == dirname(dst) {
+            format!("Renamed {} → {}", basename(src), basename(dst))
+        } else {
+            format!("Moved {} → {}", basename(src), dst)
+        };
+        self.snapshot_file_op(&message);
         info!(
             "WorkspaceState::rename_file: ok ({:.1}ms)",
             t.elapsed().as_secs_f64() * 1000.0
@@ -503,6 +538,7 @@ impl WorkspaceState {
         {
             self.clear_main_file();
         }
+        self.snapshot_file_op(&format!("Deleted folder {}", basename(path)));
         info!(
             "WorkspaceState::delete_folder: ok ({:.1}ms)",
             t.elapsed().as_secs_f64() * 1000.0
@@ -562,6 +598,12 @@ impl WorkspaceState {
             );
         }
 
+        let count = sources.len();
+        self.snapshot_file_op(&format!(
+            "Imported {count} file{} into {}",
+            if count == 1 { "" } else { "s" },
+            basename(dest_dir)
+        ));
         info!(
             "WorkspaceState::import_files: ok ({:.1}ms)",
             t.elapsed().as_secs_f64() * 1000.0
@@ -588,6 +630,12 @@ impl WorkspaceState {
             e.to_string()
         })?;
         self.update_main_file_path(&src_abs, &dst_abs, true)?;
+        let message = if dirname(src) == dirname(dst) {
+            format!("Renamed folder {} → {}", basename(src), basename(dst))
+        } else {
+            format!("Moved folder {} → {}", basename(src), dst)
+        };
+        self.snapshot_file_op(&message);
         info!(
             "WorkspaceState::move_folder: ok ({:.1}ms)",
             t.elapsed().as_secs_f64() * 1000.0
@@ -738,4 +786,23 @@ fn collect_files_recursive(dir: &Path) -> Vec<PathBuf> {
 fn rewrite_path_prefix(path: &Path, src_prefix: &Path, dst_prefix: &Path) -> Option<PathBuf> {
     let suffix = path.strip_prefix(src_prefix).ok()?;
     Some(dst_prefix.join(suffix))
+}
+
+/// Last path segment of a workspace-relative (forward- or back-slash) path,
+/// used to build human-readable restore-point messages.
+fn basename(path: &str) -> &str {
+    path.trim_end_matches(['/', '\\'])
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(path)
+}
+
+/// Parent portion of a workspace-relative path, or `""` for a top-level entry.
+/// Used to distinguish a rename (same parent) from a move (different parent).
+fn dirname(path: &str) -> &str {
+    let trimmed = path.trim_end_matches(['/', '\\']);
+    match trimmed.rfind(['/', '\\']) {
+        Some(idx) => &trimmed[..idx],
+        None => "",
+    }
 }

--- a/apps/typwriter-desktop/src-tauri/src/workspace/mod.rs
+++ b/apps/typwriter-desktop/src-tauri/src/workspace/mod.rs
@@ -120,6 +120,12 @@ impl WorkspaceState {
         self.pipeline.invalidate_cache();
         self.pipeline.attach_disk_cache(&path);
 
+        // Kick the (lazy) font search off now so the system scan overlaps the
+        // rest of the open path — watcher start, cache attach, frontend
+        // round-trips — and is usually finished by the time the first compile
+        // needs it. Idempotent, so the compile worker calling it again is free.
+        self.world.ensure_fonts_loading();
+
         // Bind the version-history system to this workspace. Initializes a
         // `.git` repo on first open and seeds an initial restore point so the
         // timeline is never empty.
@@ -155,13 +161,19 @@ impl WorkspaceState {
             if main_path.exists() {
                 info!("WorkspaceState::open_folder: restoring main file main={main:?}");
                 let _ = self.set_main_file(main_path.clone());
-                self.pipeline.request_compile(CompileReason::MainFile);
                 // Compute the workspace-relative path for the frontend (forward slashes).
                 restored_main = main_path
                     .strip_prefix(&path)
                     .ok()
                     .and_then(|r| r.to_str())
                     .map(|s| s.replace('\\', "/"));
+                // Paint the previously-rendered preview from disk straight away,
+                // so the user sees pages while fonts load and the document
+                // recompiles in the background. The compile below reconciles.
+                if let Some(rel) = &restored_main {
+                    self.pipeline.restore_preview(rel);
+                }
+                self.pipeline.request_compile(CompileReason::MainFile);
             } else {
                 warn!(
                     "WorkspaceState::open_folder: persisted main file no longer exists main={main:?}"

--- a/apps/typwriter-desktop/src-tauri/src/workspace/store.rs
+++ b/apps/typwriter-desktop/src-tauri/src/workspace/store.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use log::{info, warn};
 use serde_json::{json, Value as JsonValue};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tauri_plugin_store::StoreExt;
 
 const STORE_FILE: &str = "app_data.json";
@@ -32,6 +32,12 @@ const KEY_WORKSPACE_OPEN_TABS: &str = "workspace_open_tabs";
 /// Add `root` to the front of the recent-workspaces list, deduplicating
 /// and capping at [`MAX_RECENT`] entries.
 pub fn add_recent_workspace(handle: &AppHandle, root: &Path) {
+    // The onboarding tutorial drives a disposable scratch workspace under
+    // app-data; it must never surface in the user's recent-workspaces list.
+    if is_onboarding_workspace(handle, root) {
+        return;
+    }
+
     let t = Instant::now();
     let Ok(store) = handle.store(STORE_FILE) else {
         warn!("store: could not open {STORE_FILE}");
@@ -60,6 +66,17 @@ pub fn add_recent_workspace(handle: &AppHandle, root: &Path) {
         "store: added recent workspace ({:.1}ms)",
         t.elapsed().as_secs_f64() * 1000.0
     );
+}
+
+/// True when `root` is the onboarding tutorial's scratch workspace
+/// (`<app_data>/onboarding`). `Path` equality compares parsed components, so
+/// it is insensitive to `/` vs `\` separators.
+fn is_onboarding_workspace(handle: &AppHandle, root: &Path) -> bool {
+    handle
+        .path()
+        .app_data_dir()
+        .map(|base| base.join("onboarding").as_path() == root)
+        .unwrap_or(false)
 }
 
 /// Remove a single workspace path from the recent list.

--- a/apps/typwriter-desktop/src-tauri/src/workspace/store.rs
+++ b/apps/typwriter-desktop/src-tauri/src/workspace/store.rs
@@ -10,6 +10,7 @@
 //
 // Thumbnail PNGs are written directly to `<workspace_root>/.typwriter/thumbnail.png`.
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::Instant;
 
@@ -178,12 +179,15 @@ pub fn get_workspace_main_file(handle: &AppHandle, root: &Path) -> Option<String
 
 // ─── Per-workspace open tabs ─────────────────────────────────────────────────
 
-/// Persist the list of open tabs and the active tab for the workspace at `root`.
+/// Persist the list of open tabs, the active tab, and any unsaved editor
+/// buffers (`relPath -> content`) for the workspace at `root`. The unsaved map
+/// powers hot-exit restore: edits that never reached disk survive a teardown.
 pub fn save_workspace_tabs(
     handle: &AppHandle,
     root: &Path,
     tabs: Vec<String>,
     active_tab_id: Option<String>,
+    unsaved: HashMap<String, String>,
 ) {
     let t = Instant::now();
     let Ok(store) = handle.store(STORE_FILE) else {
@@ -209,6 +213,7 @@ pub fn save_workspace_tabs(
         json!({
             "tabs": tabs,
             "activeTabId": active_tab_id,
+            "unsaved": unsaved,
         }),
     );
 
@@ -224,7 +229,7 @@ pub fn save_workspace_tabs(
 pub fn get_workspace_tabs(
     handle: &AppHandle,
     root: &Path,
-) -> Option<(Vec<String>, Option<String>)> {
+) -> Option<(Vec<String>, Option<String>, HashMap<String, String>)> {
     let store = handle.store(STORE_FILE).ok()?;
     let root_key = root.to_string_lossy().to_string();
 
@@ -245,8 +250,14 @@ pub fn get_workspace_tabs(
     let active_tab_id: Option<String> = entry
         .get("activeTabId")
         .and_then(|v| v.as_str().map(|s| s.to_string()));
+    // `unsaved` is absent for stores written before hot-exit landed — default
+    // to empty so older state still restores cleanly.
+    let unsaved: HashMap<String, String> = entry
+        .get("unsaved")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
 
-    Some((tabs, active_tab_id))
+    Some((tabs, active_tab_id, unsaved))
 }
 
 // ─── .typwriter folder & thumbnail ───────────────────────────────────────────

--- a/apps/typwriter-desktop/src-tauri/src/world/mod.rs
+++ b/apps/typwriter-desktop/src-tauri/src/world/mod.rs
@@ -5,15 +5,18 @@ pub use progress::TauriProgress;
 
 use chrono::Datelike;
 use ecow::EcoString;
-use log::info;
-use parking_lot::{Mutex, RwLock};
+use log::{error, info};
+use parking_lot::{Condvar, Mutex, RwLock};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::OnceLock,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, OnceLock,
+    },
     time::Instant,
 };
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter};
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use tauri::Manager;
 use typst::{
@@ -62,6 +65,18 @@ pub struct EditorWorld {
 
     /// Empty fallback for `World::book()` before fonts arrive
     empty_book: LazyHash<FontBook>,
+
+    /// Single-spawn guard for the lazy background font load. Fonts are no
+    /// longer searched at startup — the first workspace open / first compile
+    /// kicks the search off, so the scan overlaps the rest of the open path.
+    font_load_started: AtomicBool,
+
+    /// `true` once a font set has been installed. Paired with `fonts_cv` so the
+    /// compile worker can block until fonts exist instead of compiling against
+    /// the empty fallback book (which would render fonts-less pages and poison
+    /// the on-disk preview cache with them).
+    fonts_ready: Mutex<bool>,
+    fonts_cv: Condvar,
 
     /// In-memory source cache: files the editor has open / has read
     /// Key: FileId, Value: the Source (typst's parsed form)
@@ -141,6 +156,9 @@ impl EditorWorld {
             library: OnceLock::new(),
             font_data: RwLock::new(None),
             empty_book: LazyHash::new(FontBook::from_fonts(&[])),
+            font_load_started: AtomicBool::new(false),
+            fonts_ready: Mutex::new(false),
+            fonts_cv: Condvar::new(),
             source_cache: Mutex::new(HashMap::new()),
             file_cache: Mutex::new(HashMap::new()),
             shadow: RwLock::new(HashMap::new()),
@@ -161,6 +179,60 @@ impl EditorWorld {
             book: LazyHash::new(book),
         }));
         *self.font_data.write() = Some(data);
+        // Mark ready and wake any compile worker blocked in
+        // `wait_until_fonts_loaded`. Keeping this in lockstep with `font_data`
+        // means "ready" always implies a usable font set is installed — true
+        // for both the initial lazy load and later settings-driven reloads.
+        *self.fonts_ready.lock() = true;
+        self.fonts_cv.notify_all();
+    }
+
+    /// Whether a font set has been installed yet.
+    pub fn fonts_ready(&self) -> bool {
+        *self.fonts_ready.lock()
+    }
+
+    /// Block the calling thread until fonts are available. The compile worker
+    /// calls this before its first compile so it never renders against the
+    /// empty fallback book.
+    pub fn wait_until_fonts_loaded(&self) {
+        let mut ready = self.fonts_ready.lock();
+        while !*ready {
+            self.fonts_cv.wait(&mut ready);
+        }
+    }
+
+    /// Kick off the background font search exactly once. Idempotent — cheap to
+    /// call on every workspace open and every compile (a single atomic swap
+    /// after the first). The system font scan can take seconds, so it runs on
+    /// its own thread; when it finishes the fonts are installed (which wakes
+    /// `wait_until_fonts_loaded`) and `app:fonts-loaded` is emitted.
+    pub fn ensure_fonts_loading(self: &Arc<Self>) {
+        if self.font_load_started.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let world = Arc::clone(self);
+        std::thread::spawn(move || {
+            let extra_dirs = crate::commands::settings::load_font_directories(&world.app_handle);
+            // A corrupt font file or a stalled font directory can panic the
+            // fontdb scan. Catch it so the compile worker is never left blocked
+            // forever — fall back to embedded fonts only, which don't touch the
+            // filesystem.
+            let searched = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                FontSearcher::new().search_with(&extra_dirs)
+            }));
+            match searched {
+                Ok(fonts) => world.load_fonts(fonts.book, fonts.fonts),
+                Err(_) => {
+                    error!("ensure_fonts_loading: font search panicked; falling back to embedded fonts only");
+                    let fonts = FontSearcher::new().include_system_fonts(false).search();
+                    world.load_fonts(fonts.book, fonts.fonts);
+                }
+            }
+            if let Err(err) = world.app_handle.emit("app:fonts-loaded", ()) {
+                error!("ensure_fonts_loading: emit app:fonts-loaded failed err=\"{err}\"");
+            }
+        });
     }
 
     /// Run a font search (system + embedded + the given extra directories)
@@ -210,6 +282,20 @@ impl EditorWorld {
     /// without it, typst would emit "cannot find main file" for every cycle.
     pub fn has_main(&self) -> bool {
         self.main.read().is_some()
+    }
+
+    /// Workspace-relative path of the current main file, normalized to forward
+    /// slashes. `None` when no main file is set. Used to tag the persisted
+    /// preview manifest so a manifest left over for a *different* main file is
+    /// ignored on the next open.
+    pub fn main_rel(&self) -> Option<String> {
+        let id = (*self.main.read())?;
+        Some(
+            id.vpath()
+                .as_rootless_path()
+                .to_string_lossy()
+                .replace('\\', "/"),
+        )
     }
 
     /// Update the workspace root and flush all file caches.

--- a/apps/typwriter-desktop/src-tauri/src/world/mod.rs
+++ b/apps/typwriter-desktop/src-tauri/src/world/mod.rs
@@ -47,6 +47,14 @@ pub struct EditorWorld {
     /// Workspace root on disk — updatable when the user opens a new folder.
     root: RwLock<PathBuf>,
 
+    /// SAF-aware filesystem provider. A workspace folder picked through
+    /// Android's Storage Access Framework is invisible to `std::fs` (the app
+    /// holds no broad storage permission), so source files, images and other
+    /// assets must be read through android-fs. `VcsState` owns the registry of
+    /// SAF roots and hands back the right [`WorkingTreeFs`] accessor; off
+    /// Android (and for the app-managed dir) this is always a std::fs accessor.
+    vcs: Arc<crate::vcs::VcsState>,
+
     /// The file currently set as "main" by the user. `None` when no main
     /// file has been chosen — we deliberately avoid a sentinel `FileId`
     /// here since any plausible sentinel path (e.g. `main.typ`) could
@@ -139,7 +147,7 @@ impl EditorWorld {
         }
     }
 
-    pub fn new(root: PathBuf, app_handle: AppHandle) -> Self {
+    pub fn new(root: PathBuf, app_handle: AppHandle, vcs: Arc<crate::vcs::VcsState>) -> Self {
         let pkg = app_handle.package_info();
         let user_agent = format!("{}/{}", pkg.name, pkg.version);
         let downloader = Downloader::new(user_agent.clone());
@@ -152,6 +160,7 @@ impl EditorWorld {
             PackageStorage::new(cache_dir, package_dir, Downloader::new(user_agent));
         Self {
             root: RwLock::new(root),
+            vcs,
             main: RwLock::new(None),
             library: OnceLock::new(),
             font_data: RwLock::new(None),
@@ -340,6 +349,39 @@ impl EditorWorld {
         self.file_cache.lock().remove(&id);
     }
 
+    /// Read a file's raw bytes for the compiler, routing workspace-local files
+    /// through the SAF-aware accessor. A folder picked via Android's Storage
+    /// Access Framework is unreachable with `std::fs`, so source files and
+    /// embedded assets (`image(...)`, `include`/`read` targets) must be read
+    /// through android-fs. Package files live in the app-private cache, which is
+    /// always reachable with `std::fs` on every platform — and lie outside the
+    /// workspace root — so they keep the direct path.
+    fn read_file_bytes(&self, id: FileId) -> FileResult<Vec<u8>> {
+        let path = self.id_to_path(id)?;
+
+        if id.package().is_some() {
+            return std::fs::read(&path).map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    FileError::NotFound(path)
+                } else {
+                    FileError::AccessDenied
+                }
+            });
+        }
+
+        let root = self.root.read().clone();
+        let fs = self.vcs.working_tree_fs_for(&root);
+        fs.read_file(&path).map_err(|_| {
+            // `WorkingTreeFs` collapses io errors to strings; recover the
+            // NotFound/AccessDenied distinction typst relies on with a probe.
+            if fs.exists(&path) {
+                FileError::AccessDenied
+            } else {
+                FileError::NotFound(path)
+            }
+        })
+    }
+
     /// Map a FileId back to an absolute path on disk.
     ///
     /// For local files, joins the root with the virtual path.
@@ -398,15 +440,9 @@ impl World for EditorWorld {
         let text = if let Some(content) = self.shadow.read().get(&id) {
             content.clone()
         } else {
-            // 3. Fall back to disk (may trigger a package download)
-            let path = self.id_to_path(id)?;
-            std::fs::read_to_string(&path).map_err(|e| {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    FileError::NotFound(path.clone())
-                } else {
-                    FileError::AccessDenied
-                }
-            })?
+            // 3. Fall back to disk/SAF (may trigger a package download)
+            let bytes = self.read_file_bytes(id)?;
+            String::from_utf8(bytes).map_err(|_| FileError::AccessDenied)?
         };
 
         let source = Source::new(id, text);
@@ -418,9 +454,7 @@ impl World for EditorWorld {
         if let Some(bytes) = self.file_cache.lock().get(&id) {
             return Ok(bytes.clone());
         }
-        let path = self.id_to_path(id)?;
-        let bytes = std::fs::read(&path).map_err(|_| FileError::NotFound(path))?;
-        let bytes = Bytes::new(bytes);
+        let bytes = Bytes::new(self.read_file_bytes(id)?);
         self.file_cache.lock().insert(id, bytes.clone());
         Ok(bytes)
     }

--- a/apps/typwriter-desktop/src-tauri/tauri.conf.json
+++ b/apps/typwriter-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "typwriter",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.ahdey.typwriter",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/apps/typwriter-desktop/src/lib/components/editor/editor-pane.svelte
+++ b/apps/typwriter-desktop/src/lib/components/editor/editor-pane.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import { HugeiconsIcon } from "@hugeicons/svelte";
   import { FileCodeIcon, BlockedIcon } from "@hugeicons/core-free-icons";
   import TabBar from "$lib/components/editor/tab-bar.svelte";
@@ -8,12 +9,26 @@
   import TypstToolbar from "$lib/components/editor/typst-toolbar.svelte";
   import { editor } from "$lib/stores/editor.svelte";
   import { platform } from "$lib/stores/platform.svelte";
+  import { logError } from "$lib/logger";
 
   const isTypstActive = $derived(
     editor.activeTab?.viewMode === "text" &&
     !editor.activeTab.isLoading &&
     editor.activeTab.relPath.endsWith(".typ"),
   );
+
+  // Navigating to another page (Settings, Home, …) unmounts the workspace and
+  // with it this editor — destroying the CodeMirror views. On mobile the
+  // save-on-blur handler already commits edits to disk before that happens;
+  // desktop has no such path, so flush here too. flushAllTabs reads each tab's
+  // buffer from the store (kept current by the update listener), not from the
+  // now-torn-down CM views, so it's unaffected by the unmount order. Dirty
+  // tabs are saved; clean ones are a no-op.
+  onDestroy(() => {
+    void editor.flushAllTabs().catch((err) =>
+      logError("editor-pane unmount flush failed:", err),
+    );
+  });
 </script>
 
 <div class="flex h-full flex-col bg-background {platform.isMobile ? 'pb-2' : ''}">

--- a/apps/typwriter-desktop/src/lib/components/editor/onboarding-editor.svelte
+++ b/apps/typwriter-desktop/src/lib/components/editor/onboarding-editor.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import {
+    EditorView,
+    keymap,
+    drawSelection,
+    highlightActiveLine,
+  } from "@codemirror/view";
+  import { EditorState, Compartment } from "@codemirror/state";
+  import {
+    defaultKeymap,
+    history,
+    historyKeymap,
+    indentWithTab,
+  } from "@codemirror/commands";
+  import {
+    indentOnInput,
+    syntaxHighlighting,
+    defaultHighlightStyle,
+    bracketMatching,
+  } from "@codemirror/language";
+  import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+  import { languages } from "@codemirror/language-data";
+  import { untrack } from "svelte";
+  import { mode, systemPrefersMode } from "mode-watcher";
+
+  import { typst, light, dark, typstKeymap } from "$lib/typst-codemirror-lang";
+  import { settings } from "$lib/stores/settings.svelte";
+
+  /**
+   * A deliberately minimal, single-document CodeMirror editor for the tutorial.
+   *
+   * It has no tabs, no IPC, and no dependency on the `editor` store — the
+   * onboarding store owns the shadow-write + recompile flow. This component is
+   * purely a controlled text widget:
+   *  - `value` is the content to display.
+   *  - `seedVersion` is a monotonic counter; whenever it changes the editor
+   *    reseeds its document from the *current* `value` (used on step change and
+   *    "Reset example"). While the user types, the editor is the source of
+   *    truth and reports edits via `onchange` without any reseed.
+   */
+  interface Props {
+    value: string;
+    seedVersion: number;
+    onchange: (value: string) => void;
+  }
+  let { value, seedVersion, onchange }: Props = $props();
+
+  let host = $state<HTMLDivElement | null>(null);
+  let view: EditorView | null = null;
+  // Guards the updateListener while we programmatically reseed the document,
+  // so a reseed never echoes back through `onchange`.
+  let suppress = false;
+
+  const themeCompartment = new Compartment();
+  const fontCompartment = new Compartment();
+
+  function resolvedTheme() {
+    const m = mode.current;
+    const sys = systemPrefersMode.current;
+    return m === "dark" || sys === "dark" ? dark : light;
+  }
+
+  function fontExtension() {
+    const family = settings.editorFontFamily;
+    const quoted =
+      family.includes(" ") && !family.includes('"') ? `"${family}"` : family;
+    return EditorView.theme({
+      "&": {
+        fontSize: `${settings.editorFontSize}px`,
+        fontFamily: `${quoted}, var(--font-mono, monospace)`,
+      },
+      ".cm-content, .cm-gutters": {
+        fontFamily: `${quoted}, var(--font-mono, monospace)`,
+      },
+    });
+  }
+
+  // Create the view once the host is mounted. Everything except the `host`
+  // dependency is read untracked so the editor isn't torn down and recreated
+  // on every keystroke (value), theme, or font change — those are handled by
+  // the reconfigure effects below.
+  $effect(() => {
+    const el = host;
+    if (!el) return;
+
+    const v = untrack(() => new EditorView({
+      parent: el,
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          highlightActiveLine(),
+          history(),
+          drawSelection(),
+          bracketMatching(),
+          closeBrackets(),
+          indentOnInput(),
+          syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+          themeCompartment.of(resolvedTheme()),
+          fontCompartment.of(fontExtension()),
+          typst({ codeLanguages: languages }),
+          // No line-number gutter — the tutorial editor is deliberately bare.
+          keymap.of(typstKeymap),
+          keymap.of([
+            ...defaultKeymap,
+            ...historyKeymap,
+            ...closeBracketsKeymap,
+            indentWithTab,
+          ]),
+          EditorView.updateListener.of((update) => {
+            if (suppress || !update.docChanged) return;
+            onchange(update.state.doc.toString());
+          }),
+          EditorView.theme({
+            "&": { height: "100%", width: "100%" },
+            ".cm-scroller": { overflow: "auto" },
+            ".cm-content": { paddingLeft: "0.875rem" },
+          }),
+        ],
+      }),
+    }));
+    view = v;
+    return () => {
+      v.destroy();
+      view = null;
+    };
+  });
+
+  // Reseed on step change / reset. Tracks `seedVersion` only; reads `value`
+  // untracked so per-keystroke value changes don't fight the editor.
+  $effect(() => {
+    seedVersion;
+    untrack(() => {
+      const v = view;
+      if (!v) return;
+      const next = value;
+      if (v.state.doc.toString() === next) return;
+      suppress = true;
+      v.dispatch({
+        changes: { from: 0, to: v.state.doc.length, insert: next },
+        selection: { anchor: 0 },
+        scrollIntoView: true,
+      });
+      suppress = false;
+    });
+  });
+
+  // Reconfigure theme on light/dark change.
+  $effect(() => {
+    mode.current;
+    systemPrefersMode.current;
+    const ext = resolvedTheme();
+    untrack(() => view?.dispatch({ effects: themeCompartment.reconfigure(ext) }));
+  });
+
+  // Reconfigure font on settings change.
+  $effect(() => {
+    settings.editorFontFamily;
+    settings.editorFontSize;
+    const ext = fontExtension();
+    untrack(() => view?.dispatch({ effects: fontCompartment.reconfigure(ext) }));
+  });
+</script>
+
+<div bind:this={host} class="h-full w-full overflow-hidden"></div>

--- a/apps/typwriter-desktop/src/lib/components/editor/text-editor-tab.svelte
+++ b/apps/typwriter-desktop/src/lib/components/editor/text-editor-tab.svelte
@@ -399,6 +399,21 @@
         if (!update.docChanged) return;
         editor.handleTabContentChange(tabId, update.state.doc.toString());
       }),
+      // Mobile: save on blur. The soft keyboard dismissing or the app being
+      // backgrounded blurs the editor; persisting here shrinks the window
+      // where edits live only in memory before the OS can kill the WebView.
+      ...(platform.isMobile
+        ? [
+            EditorView.domEventHandlers({
+              blur: () => {
+                editor
+                  .saveTabById(tabId)
+                  .mapErr((err) => logError("save-on-blur error:", err));
+                return false;
+              },
+            }),
+          ]
+        : []),
       EditorView.updateListener.of((update) => {
         if (!update.selectionSet) return;
         const tab = editor.tabs.find((t) => t.id === tabId);

--- a/apps/typwriter-desktop/src/lib/components/pages/home.svelte
+++ b/apps/typwriter-desktop/src/lib/components/pages/home.svelte
@@ -6,10 +6,11 @@
   import { onAppFontsLoaded, type UnlistenFn } from "$lib/ipc/events";
   import type { RecentWorkspaceEntry } from "$lib/types";
   import { workspace } from "$lib/stores/workspace.svelte";
+  import { onboarding } from "$lib/stores/onboarding.svelte";
   import { open as openDialog } from "@tauri-apps/plugin-dialog";
   import { AndroidFs } from "tauri-plugin-android-fs-api";
   import { HugeiconsIcon } from "@hugeicons/svelte";
-  import { Folder01Icon, FolderOpenIcon, FolderAddIcon, Delete01Icon, Cancel01Icon, BookOpen01Icon, Refresh01Icon, File01Icon, KeyboardIcon, Settings01Icon } from "@hugeicons/core-free-icons";
+  import { Folder01Icon, FolderOpenIcon, FolderAddIcon, Delete01Icon, Cancel01Icon, BookOpen01Icon, Refresh01Icon, File01Icon, KeyboardIcon, Settings01Icon, Mortarboard01Icon } from "@hugeicons/core-free-icons";
   import { openUrl, openPath } from "@tauri-apps/plugin-opener";
   import { updater } from "$lib/stores/updater.svelte";
   import { toast } from "svelte-sonner";
@@ -60,6 +61,21 @@
   // ── Font readiness ──────────────────────────────────────────────────────────
 
   let unlistenFonts: UnlistenFn | null = null;
+  let onboardingChecked = false;
+
+  /** Auto-show the tutorial once, on first launch, after fonts are ready (it
+   *  compiles examples). Desktop only for this pass. The Rust-side flag is the
+   *  source of truth, so this is a no-op on every subsequent launch. */
+  async function maybeAutoShowOnboarding() {
+    if (onboardingChecked || platform.isMobile) return;
+    onboardingChecked = true;
+    const result = await onboarding.shouldAutoShow();
+    if (result.isOk() && result.value) {
+      page.navigate("onboarding");
+    } else if (result.isErr()) {
+      logError("Failed to read onboarding flag:", result.error);
+    }
+  }
 
   onMount(async () => {
     loadRecent();
@@ -68,6 +84,7 @@
     const ready = await isFontsLoaded();
     if (ready.isOk() && ready.value) {
       fontsReady = true;
+      maybeAutoShowOnboarding();
     } else {
       fontToastId = toast.loading("Loading fonts…");
       const result = await onAppFontsLoaded(() => {
@@ -76,6 +93,7 @@
           toast.dismiss(fontToastId);
           fontToastId = undefined;
         }
+        maybeAutoShowOnboarding();
       });
       if (result.isOk()) unlistenFonts = result.value;
     }
@@ -457,6 +475,17 @@
       </Button>
       <ModeSwitcher />
     {:else}
+      <Button
+        variant="link"
+        size="sm"
+        class="gap-1.5 text-muted-foreground"
+        onclick={() => page.navigate("onboarding")}
+        disabled={!fontsReady}
+      >
+        <HugeiconsIcon icon={Mortarboard01Icon} class="size-3.5" />
+        Tutorial
+      </Button>
+
       <Button
         variant="link"
         size="sm"

--- a/apps/typwriter-desktop/src/lib/components/pages/home.svelte
+++ b/apps/typwriter-desktop/src/lib/components/pages/home.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-  import { onMount, onDestroy } from "svelte";
+  import { onMount } from "svelte";
   import { page } from "@/stores/page.svelte";
   import Button from "../ui/button/button.svelte";
-  import { getRecentWorkspaces, createWorkspace, isFontsLoaded, removeRecentWorkspace, clearRecentWorkspaces, getLogFilePath, registerSafWorkspaceRoot } from "$lib/ipc/commands";
-  import { onAppFontsLoaded, type UnlistenFn } from "$lib/ipc/events";
+  import { getRecentWorkspaces, createWorkspace, removeRecentWorkspace, clearRecentWorkspaces, getLogFilePath, registerSafWorkspaceRoot } from "$lib/ipc/commands";
   import type { RecentWorkspaceEntry } from "$lib/types";
   import { workspace } from "$lib/stores/workspace.svelte";
   import { onboarding } from "$lib/stores/onboarding.svelte";
@@ -25,8 +24,6 @@
 
   let recentWorkspaces = $state<RecentWorkspaceEntry[]>([]);
   let loading = $state(true);
-  let fontsReady = $state(false);
-  let fontToastId = $state<string | number | undefined>();
 
   // New workspace dialog state
   let newWorkspaceOpen = $state(false);
@@ -58,14 +55,14 @@
     }
   }
 
-  // ── Font readiness ──────────────────────────────────────────────────────────
+  // ── Onboarding ────────────────────────────────────────────────────────────
 
-  let unlistenFonts: UnlistenFn | null = null;
   let onboardingChecked = false;
 
-  /** Auto-show the tutorial once, on first launch, after fonts are ready (it
-   *  compiles examples). Desktop only for this pass. The Rust-side flag is the
-   *  source of truth, so this is a no-op on every subsequent launch. */
+  /** Auto-show the tutorial once, on first launch. It compiles examples, but
+   *  fonts now load lazily on the first compile, so there's nothing to wait for
+   *  here. Desktop only for this pass. The Rust-side flag is the source of
+   *  truth, so this is a no-op on every subsequent launch. */
   async function maybeAutoShowOnboarding() {
     if (onboardingChecked || platform.isMobile) return;
     onboardingChecked = true;
@@ -77,31 +74,9 @@
     }
   }
 
-  onMount(async () => {
+  onMount(() => {
     loadRecent();
-
-    // Check if fonts already loaded (handles race condition)
-    const ready = await isFontsLoaded();
-    if (ready.isOk() && ready.value) {
-      fontsReady = true;
-      maybeAutoShowOnboarding();
-    } else {
-      fontToastId = toast.loading("Loading fonts…");
-      const result = await onAppFontsLoaded(() => {
-        fontsReady = true;
-        if (fontToastId !== undefined) {
-          toast.dismiss(fontToastId);
-          fontToastId = undefined;
-        }
-        maybeAutoShowOnboarding();
-      });
-      if (result.isOk()) unlistenFonts = result.value;
-    }
-  });
-
-  onDestroy(() => {
-    unlistenFonts?.();
-    if (fontToastId !== undefined) toast.dismiss(fontToastId);
+    maybeAutoShowOnboarding();
   });
 
   // ── Workspace operations ────────────────────────────────────────────────────
@@ -299,7 +274,6 @@
               variant="outline"
               class="h-auto md:h-auto w-full justify-start gap-3 rounded-md border border-border bg-card px-3 py-2.5 text-left font-normal hover:bg-accent hover:text-accent-foreground"
               onclick={() => handleOpenRecent(entry.path)}
-              disabled={!fontsReady}
             >
               <HugeiconsIcon icon={Folder01Icon} class="size-5 shrink-0 text-muted-foreground" />
               <div class="min-w-0 flex-1">
@@ -326,7 +300,6 @@
                        <button
                          class="group/card flex w-full flex-col overflow-hidden rounded-md border border-border bg-card text-left transition-colors hover:bg-accent disabled:pointer-events-none cursor-pointer disabled:opacity-50"
                          onclick={() => handleOpenRecent(entry.path)}
-                         disabled={!fontsReady}
                        >
                          <!-- Thumbnail -->
                          <div class="flex h-28 w-full items-center justify-center overflow-hidden bg-muted">
@@ -373,7 +346,7 @@
     <Dialog.Root bind:open={newWorkspaceOpen}>
       <Dialog.Trigger>
         {#snippet child({ props })}
-          <Button {...props} variant="outline" class="gap-2" disabled={!fontsReady}>
+          <Button {...props} variant="outline" class="gap-2">
             <HugeiconsIcon icon={FolderAddIcon} class="size-4" />
             New Workspace
           </Button>
@@ -446,7 +419,7 @@
       </Dialog.Content>
     </Dialog.Root>
 
-    <Button onclick={handleOpenNew} class="gap-2" disabled={!fontsReady}>
+    <Button onclick={handleOpenNew} class="gap-2">
       <HugeiconsIcon icon={FolderOpenIcon} class="size-4" />
       Open Folder
     </Button>
@@ -480,7 +453,6 @@
         size="sm"
         class="gap-1.5 text-muted-foreground"
         onclick={() => page.navigate("onboarding")}
-        disabled={!fontsReady}
       >
         <HugeiconsIcon icon={Mortarboard01Icon} class="size-3.5" />
         Tutorial

--- a/apps/typwriter-desktop/src/lib/components/pages/onboarding.svelte
+++ b/apps/typwriter-desktop/src/lib/components/pages/onboarding.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { HugeiconsIcon } from "@hugeicons/svelte";
+  import {
+    BookOpen01Icon,
+    ArrowLeft01Icon,
+    ArrowRight01Icon,
+    Cancel01Icon,
+    RefreshIcon,
+    CheckmarkCircle02Icon,
+  } from "@hugeicons/core-free-icons";
+  import { openUrl } from "@tauri-apps/plugin-opener";
+  import { toast } from "svelte-sonner";
+
+  import * as Resizable from "$lib/components/ui/resizable/index.js";
+  import * as ScrollArea from "$lib/components/ui/scroll-area/index.js";
+  import * as Tooltip from "$lib/components/ui/tooltip/index.js";
+  import { Button } from "$lib/components/ui/button";
+  import Titlebar from "$lib/components/titlebar/titlebar.svelte";
+  import OnboardingEditor from "$lib/components/editor/onboarding-editor.svelte";
+  import Preview from "$lib/components/sidebar/preview.svelte";
+
+  import { onboarding } from "$lib/stores/onboarding.svelte";
+  import { preview } from "$lib/stores/preview.svelte";
+  import { logError } from "$lib/logger";
+
+  const DOCS_URL = "https://typst.app/docs/";
+
+  let entering = $state(true);
+
+  onMount(async () => {
+    // Preview listeners must be live before the scratch workspace starts
+    // compiling (enter() triggers the first compile), otherwise the initial
+    // page events are missed.
+    try {
+      await preview.init();
+    } catch (err) {
+      logError("onboarding: preview init failed:", err);
+    }
+
+    const result = await onboarding.enter();
+    entering = false;
+    result.mapErr((err) => {
+      logError("onboarding: enter failed:", err);
+      toast.error(`Couldn't start the tutorial: ${err}`);
+    });
+  });
+
+  onDestroy(() => {
+    preview.destroy();
+    // Safety net: if the page is torn down without going through Finish/Skip,
+    // still mark the tutorial as dismissed.
+    if (onboarding.ready) {
+      onboarding.skip().mapErr((err) => logError("onboarding: cleanup leave failed:", err));
+    }
+  });
+
+  function handleNext() {
+    if (onboarding.isLast) {
+      onboarding.finish().mapErr((err) => {
+        logError("onboarding: finish failed:", err);
+        toast.error(`Couldn't close the tutorial: ${err}`);
+      });
+    } else {
+      onboarding.next();
+    }
+  }
+
+  function handleSkip() {
+    onboarding.skip().mapErr((err) => {
+      logError("onboarding: skip failed:", err);
+      toast.error(`Couldn't close the tutorial: ${err}`);
+    });
+  }
+
+  function handleOpenDocs() {
+    openUrl(DOCS_URL).catch((err) => logError("onboarding: open docs failed:", err));
+  }
+</script>
+
+<Tooltip.Provider>
+<div class="flex h-full w-full flex-col">
+  <Titlebar variant="minimal" title="Typwriter — Tutorial" />
+
+  <main class="flex min-h-0 flex-1 flex-col">
+    {#if entering}
+      <div class="flex flex-1 items-center justify-center">
+        <span class="text-sm text-muted-foreground">Preparing the tutorial…</span>
+      </div>
+    {:else}
+      <Resizable.PaneGroup direction="horizontal" class="min-h-0 flex-1">
+        <!-- ── Left column: explanation stacked over the editor ─────────── -->
+        <Resizable.Pane defaultSize={50} minSize={32}>
+          <Resizable.PaneGroup direction="vertical" class="h-full">
+            <Resizable.Pane defaultSize={58} minSize={20}>
+              <ScrollArea.Root class="h-full">
+                <div class="flex flex-col gap-4 p-6">
+              <div class="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <span>Step {onboarding.stepIndex + 1} of {onboarding.steps.length}</span>
+              </div>
+
+              <h1 class="text-2xl font-semibold text-foreground">
+                {onboarding.current.title}
+              </h1>
+
+              <p class="text-sm leading-relaxed text-muted-foreground">
+                {onboarding.current.blurb}
+              </p>
+
+              {#if onboarding.current.bullets?.length}
+                <ul class="flex flex-col gap-2">
+                  {#each onboarding.current.bullets as bullet (bullet)}
+                    <li class="flex items-start gap-2 text-sm text-foreground">
+                      <HugeiconsIcon
+                        icon={CheckmarkCircle02Icon}
+                        class="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                      />
+                      <span>{bullet}</span>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+
+              {#if onboarding.current.tryThis}
+                <div class="rounded-md border border-border bg-muted/40 p-3">
+                  <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Try this
+                  </p>
+                  <p class="mt-1 text-sm text-foreground">{onboarding.current.tryThis}</p>
+                </div>
+              {/if}
+
+              <div class="flex flex-wrap items-center gap-2 pt-1">
+                <Button variant="outline" size="sm" class="gap-1.5" onclick={() => onboarding.resetExample()}>
+                  <HugeiconsIcon icon={RefreshIcon} class="size-3.5" />
+                  Reset example
+                </Button>
+
+                {#if onboarding.isLast}
+                  <Button variant="outline" size="sm" class="gap-1.5" onclick={handleOpenDocs}>
+                    <HugeiconsIcon icon={BookOpen01Icon} class="size-3.5" />
+                    Open the docs
+                  </Button>
+                {/if}
+              </div>
+                </div>
+              </ScrollArea.Root>
+            </Resizable.Pane>
+
+            <Resizable.Handle />
+
+            <!-- Editor, directly below the explanation -->
+            <Resizable.Pane defaultSize={42} minSize={25}>
+              <div class="h-full border-t border-border">
+                <OnboardingEditor
+                  value={onboarding.activeContent}
+                  seedVersion={onboarding.seedVersion}
+                  onchange={(v) => onboarding.handleContentChange(v)}
+                />
+              </div>
+            </Resizable.Pane>
+          </Resizable.PaneGroup>
+        </Resizable.Pane>
+
+        <Resizable.Handle />
+
+        <!-- ── Right column: the live preview ───────────────────────────── -->
+        <Resizable.Pane defaultSize={50} minSize={30}>
+          <div class="h-full border-l border-border bg-background">
+            <Preview />
+          </div>
+        </Resizable.Pane>
+      </Resizable.PaneGroup>
+
+      <!-- ── Footer: skip · stepper · back/next ─────────────────────────── -->
+      <footer class="flex h-14 shrink-0 items-center justify-between border-t border-border px-4">
+        <Button variant="ghost" size="sm" class="gap-1.5 text-muted-foreground" onclick={handleSkip}>
+          <HugeiconsIcon icon={Cancel01Icon} class="size-3.5" />
+          Skip tutorial
+        </Button>
+
+        <div class="flex items-center gap-1.5">
+          {#each onboarding.steps as step, i (step.id)}
+            <button
+              class="size-2 rounded-full transition-colors {i === onboarding.stepIndex
+                ? 'bg-foreground'
+                : i < onboarding.stepIndex
+                  ? 'bg-foreground/40'
+                  : 'bg-border hover:bg-foreground/30'}"
+              aria-label="Go to step {i + 1}: {step.title}"
+              aria-current={i === onboarding.stepIndex ? "step" : undefined}
+              onclick={() => onboarding.goTo(i)}
+            ></button>
+          {/each}
+        </div>
+
+        <div class="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            class="gap-1.5"
+            disabled={onboarding.isFirst}
+            onclick={() => onboarding.prev()}
+          >
+            <HugeiconsIcon icon={ArrowLeft01Icon} class="size-3.5" />
+            Back
+          </Button>
+
+          <Button size="sm" class="gap-1.5" onclick={handleNext}>
+            {#if onboarding.isLast}
+              Start writing
+              <HugeiconsIcon icon={CheckmarkCircle02Icon} class="size-3.5" />
+            {:else}
+              Next
+              <HugeiconsIcon icon={ArrowRight01Icon} class="size-3.5" />
+            {/if}
+          </Button>
+        </div>
+      </footer>
+    {/if}
+  </main>
+</div>
+</Tooltip.Provider>

--- a/apps/typwriter-desktop/src/lib/components/pages/settings.svelte
+++ b/apps/typwriter-desktop/src/lib/components/pages/settings.svelte
@@ -15,6 +15,7 @@
     FileCodeIcon,
     FloppyDiskIcon,
     GitCommitIcon,
+    BookOpen01Icon,
   } from "@hugeicons/core-free-icons";
   import Button from "$lib/components/ui/button/button.svelte";
   import { Switch } from "$lib/components/ui/switch/index.js";
@@ -33,7 +34,7 @@
   } from "$lib/stores/settings.svelte";
   import { open as openDialog } from "@tauri-apps/plugin-dialog";
   import { AndroidFs } from "tauri-plugin-android-fs-api";
-  import { importFontDirectoryUri, safTreeUriToPath } from "$lib/ipc/commands";
+  import { importFontDirectoryUri, safTreeUriToPath, setOnboardingCompleted } from "$lib/ipc/commands";
   import { toast } from "svelte-sonner";
   import { logError } from "$lib/logger";
 
@@ -137,6 +138,14 @@
   }
   function selectDarkTheme(id: ThemeId) {
     settings.setDarkTheme(id);
+  }
+
+  async function handleResetTutorial() {
+    const result = await setOnboardingCompleted(false);
+    result.match(
+      () => toast.success("Tutorial reset — it will show again on next launch"),
+      (err) => toast.error(`Couldn't reset the tutorial: ${err}`),
+    );
   }
 
   function resetSettings() {
@@ -744,6 +753,39 @@
                 onCheckedChange={(v) => settings.setAutoCheckUpdates(v)}
               />
             </label>
+          </section>
+
+          <!-- ── Tutorial ────────────────────────────────────────────────── -->
+          <section>
+            <div class="mb-3 flex items-center gap-2">
+              <HugeiconsIcon icon={BookOpen01Icon} class="size-4 text-muted-foreground" />
+              <h2 class="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+                Tutorial
+              </h2>
+            </div>
+            <p class="mb-4 text-sm text-muted-foreground">
+              The onboarding tutorial shows once on first launch. Reset it to mark
+              it as not yet completed so it appears again the next time Typwriter
+              starts.
+            </p>
+
+            <div class="flex items-center justify-between gap-4 rounded-md border border-border px-4 py-3">
+              <div class="min-w-0">
+                <p class="text-sm font-medium">Reset tutorial</p>
+                <p class="truncate text-xs text-muted-foreground">
+                  Sets the "tutorial completed" flag back to false.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                class="gap-2 shrink-0"
+                onclick={handleResetTutorial}
+              >
+                <HugeiconsIcon icon={RefreshIcon} class="size-4" />
+                Reset tutorial
+              </Button>
+            </div>
           </section>
         {/if}
 

--- a/apps/typwriter-desktop/src/lib/components/pages/workspace.svelte
+++ b/apps/typwriter-desktop/src/lib/components/pages/workspace.svelte
@@ -168,7 +168,14 @@
             variant="ghost"
             size="icon-lg"
             class="bg-background/30 backdrop-blur-sm shadow-sm rounded-full pointer-events-auto"
-            onclick={() => (mobileView = mobileView === "editor" ? "preview" : "editor")}
+            onclick={() => {
+              // Leaving the editor for the preview: flush so the rendered
+              // preview reflects the latest edits and the buffer is on disk.
+              if (mobileView === "editor") {
+                void editor.flushActiveTab();
+              }
+              mobileView = mobileView === "editor" ? "preview" : "editor";
+            }}
             aria-label={mobileView === "editor" ? "Show preview" : "Show editor"}
           >
             <HugeiconsIcon

--- a/apps/typwriter-desktop/src/lib/components/vcs/timeline.svelte
+++ b/apps/typwriter-desktop/src/lib/components/vcs/timeline.svelte
@@ -23,6 +23,7 @@
     Tag01Icon,
     GitCompareIcon,
     FloppyDiskIcon,
+    FileEditIcon,
     MoreHorizontalIcon,
     PlusSignIcon,
     ArrowDown01Icon,
@@ -60,6 +61,7 @@
     save: "Save",
     compile: "Compile",
     pre_restore: "Pre-restore",
+    file_op: "File change",
   };
 
   const triggerIcon: Record<CommitTrigger, typeof PlayIcon> = {
@@ -68,6 +70,7 @@
     save: FloppyDiskIcon,
     compile: PlayIcon,
     pre_restore: ArrowReloadHorizontalIcon,
+    file_op: FileEditIcon,
   };
 
   function shortId(id: string): string {

--- a/apps/typwriter-desktop/src/lib/ipc/commands.ts
+++ b/apps/typwriter-desktop/src/lib/ipc/commands.ts
@@ -404,6 +404,36 @@ export function isFontsLoaded() {
     return ResultAsync.fromPromise(invoke<boolean>('is_fonts_loaded'), toErrString);
 }
 
+// ─── Onboarding ─────────────────────────────────────────────────────────────────
+
+/** A single seed file for the onboarding workspace. */
+export interface OnboardingFile {
+    name: string;
+    content: string;
+}
+
+/** Create (or re-seed) the disposable onboarding workspace under app-data and
+ *  return its absolute path. Each tutorial step is seeded as its own `*.typ`
+ *  file before the workspace is opened. */
+export function prepareOnboardingWorkspace(files: OnboardingFile[]) {
+    return ResultAsync.fromPromise(
+        invoke<string>('prepare_onboarding_workspace', { files }),
+        toErrString
+    );
+}
+
+/** Whether onboarding has been shown (completed OR skipped). */
+export function getOnboardingCompleted() {
+    return ResultAsync.fromPromise(invoke<boolean>('get_onboarding_completed'), toErrString);
+}
+
+export function setOnboardingCompleted(completed: boolean) {
+    return ResultAsync.fromPromise(
+        invoke<void>('set_onboarding_completed', { completed }),
+        toErrString
+    );
+}
+
 // ─── Settings ─────────────────────────────────────────────────────────────────
 
 export interface AppSettings {

--- a/apps/typwriter-desktop/src/lib/ipc/commands.ts
+++ b/apps/typwriter-desktop/src/lib/ipc/commands.ts
@@ -142,16 +142,22 @@ export function clearRecentWorkspaces() {
     return ResultAsync.fromPromise(invoke<void>('clear_recent_workspaces'), toErrString);
 }
 
-export function saveWorkspaceTabs(tabs: string[], activeTabId: string | null) {
+export function saveWorkspaceTabs(
+    tabs: string[],
+    activeTabId: string | null,
+    unsaved: Record<string, string> = {}
+) {
     return ResultAsync.fromPromise(
-        invoke<void>('save_workspace_tabs', { tabs, activeTabId }),
+        invoke<void>('save_workspace_tabs', { tabs, activeTabId, unsaved }),
         toErrString
     );
 }
 
 export function getWorkspaceTabs(root: string) {
     return ResultAsync.fromPromise(
-        invoke<[string[], string | null] | null>('get_workspace_tabs', { root }),
+        invoke<[string[], string | null, Record<string, string>] | null>('get_workspace_tabs', {
+            root,
+        }),
         toErrString
     );
 }

--- a/apps/typwriter-desktop/src/lib/stores/editor.svelte.ts
+++ b/apps/typwriter-desktop/src/lib/stores/editor.svelte.ts
@@ -38,6 +38,13 @@ function imageAssetSrc(path: string): string {
     return convertFileSrc(normalize(path));
 }
 
+/** Resolve the <img> src for an image read response. SAF workspace roots can't
+ *  be reached by the asset protocol, so the backend ships the bytes inline as a
+ *  `data:` URL — prefer it when present, otherwise convert the path. */
+function imageSrcFromResponse(res: { path: string; data?: string | null }): string {
+    return res.data ?? imageAssetSrc(res.path);
+}
+
 export interface TabInfo {
     id: string;
     relPath: string;
@@ -155,6 +162,88 @@ class EditorStore {
         workspace.schedulePersistTabs();
     }
 
+    /** Restore a set of tabs at workspace-open time.
+     *
+     *  Tab descriptors are created synchronously so the tab-bar order matches
+     *  the persisted order, then every tab's on-disk content is loaded
+     *  *concurrently*. Reading each file is an IPC round-trip; doing them one
+     *  after another (the previous per-tab `openFile` loop) made workspace open
+     *  scale linearly with tab count — painfully so on mobile where IPC latency
+     *  dominates. Unsaved (hot-exit) buffers are seeded without a disk read.
+     *
+     *  Assumes the editor was just reset (no existing tabs) — the workspace
+     *  open path calls `reset()` before this. */
+    async restoreTabs(
+        tabPaths: string[],
+        activeTabId: string | null,
+        unsaved: Record<string, string>,
+    ): Promise<void> {
+        const loads: Promise<void>[] = [];
+
+        for (const relPath of tabPaths) {
+            const id = normalize(relPath);
+            if (this.tabs.find((t) => t.id === id)) {
+                continue;
+            }
+
+            const absPath = workspace.toAbs(id);
+            const ext = extOf(id);
+            const viewMode: ViewMode = IMAGE_EXTS.has(ext)
+                ? 'image'
+                : TEXT_EXTS.has(ext)
+                    ? 'text'
+                    : 'unsupported';
+
+            const tab: TabInfo = {
+                id,
+                relPath: id,
+                absPath,
+                name: basename(id),
+                viewMode,
+                isEditable: viewMode === 'text',
+                content: '',
+                imageSrc: null,
+                hasUnsavedChanges: false,
+                isLoading: viewMode !== 'unsupported',
+            };
+            this.tabs.push(tab);
+
+            if (viewMode === 'unsupported') {
+                continue;
+            }
+
+            // Hot-exit restore: seed from the durable unsaved buffer instead of
+            // the now-stale disk copy, mark the tab dirty, and re-seed the Rust
+            // shadow so the next compile renders the restored buffer. Mirrors
+            // the unsaved-content branch in `_openFile`.
+            const override = unsaved[relPath] ?? unsaved[id];
+            if (typeof override === 'string' && viewMode === 'text') {
+                tab.content = override;
+                tab.hasUnsavedChanges = true;
+                tab.isLoading = false;
+                updateFileContent(tab.absPath, override).mapErr((err) =>
+                    logError('restore unsaved shadow write failed:', err)
+                );
+                continue;
+            }
+
+            loads.push(
+                this._loadTabContent(id, absPath, viewMode).catch((err) =>
+                    logError(`restore tab failed for ${relPath}:`, err)
+                )
+            );
+        }
+
+        await Promise.all(loads);
+
+        // Activate the previously-active tab, falling back to the first one.
+        this.activeTabId =
+            activeTabId && this.tabs.some((t) => t.id === activeTabId)
+                ? activeTabId
+                : (this.tabs[0]?.id ?? null);
+        workspace.schedulePersistTabs();
+    }
+
     private async _loadTabContent(tabId: string, absPath: string, viewMode: ViewMode): Promise<void> {
         const response = await readFile(absPath);
         const liveTab = this.tabs.find((t) => t.id === tabId);
@@ -170,7 +259,7 @@ class EditorStore {
             if (response.value.type !== 'image') {
                 throw new Error(`Expected image, got ${response.value.type}`);
             }
-            liveTab.imageSrc = imageAssetSrc(response.value.path);
+            liveTab.imageSrc = imageSrcFromResponse(response.value);
             liveTab.content = '';
         } else {
             if (response.value.type !== 'text') {
@@ -254,7 +343,17 @@ class EditorStore {
         tab.content = content;
         tab.hasUnsavedChanges = true;
 
-        this._scheduleTypingPreview(tab);
+        // Live, per-keystroke preview is a desktop-only luxury. On mobile it is
+        // (a) invisible — the preview is a separate, toggled view that is not
+        // shown while editing — and (b) ruinously expensive: each tick ships the
+        // *entire* document across the WebView IPC bridge on the main thread and
+        // queues a recompile, which is exactly what makes typing freeze. On
+        // mobile the shadow buffer and the preview are instead refreshed by
+        // idle-save, save-on-blur, and the editor→preview view toggle — all of
+        // which save the file and trigger a recompile (see save_file in Rust).
+        if (!platform.isMobile) {
+            this._scheduleTypingPreview(tab);
+        }
         this._scheduleIdleSave(tab);
         // Persist the unsaved buffer to durable storage (debounced) so it
         // survives a non-graceful teardown — see getTabState / hot-exit restore.
@@ -395,7 +494,7 @@ class EditorStore {
 
             if (tab.viewMode === 'image') {
                 if (response.value.type === 'image') {
-                    tab.imageSrc = imageAssetSrc(response.value.path);
+                    tab.imageSrc = imageSrcFromResponse(response.value);
                 }
                 tab.hasUnsavedChanges = false;
                 continue;

--- a/apps/typwriter-desktop/src/lib/stores/editor.svelte.ts
+++ b/apps/typwriter-desktop/src/lib/stores/editor.svelte.ts
@@ -12,6 +12,7 @@ import {
 import type { CompileReason } from '$lib/types';
 import { workspace } from './workspace.svelte';
 import { settings } from './settings.svelte';
+import { platform } from './platform.svelte';
 import { normalize, basename } from '$lib/paths';
 import { logError } from '$lib/logger';
 import { toast } from 'svelte-sonner';
@@ -81,11 +82,11 @@ class EditorStore {
         this.cursorJumpRequest = { tabId, offset };
     }
 
-    openFile(relPath: string): ResultAsync<void, string> {
-        return ResultAsync.fromPromise(this._openFile(relPath), (err) => String(err));
+    openFile(relPath: string, unsavedContent?: string): ResultAsync<void, string> {
+        return ResultAsync.fromPromise(this._openFile(relPath, unsavedContent), (err) => String(err));
     }
 
-    private async _openFile(relPath: string): Promise<void> {
+    private async _openFile(relPath: string, unsavedContent?: string): Promise<void> {
         const id = normalize(relPath);
         if (this.activeTabId && this.activeTabId !== id) {
             await this.flushActiveTab();
@@ -124,6 +125,21 @@ class EditorStore {
         workspace.schedulePersistTabs();
 
         if (viewMode === 'unsupported') {
+            return;
+        }
+
+        // Hot-exit restore: if durable unsaved content was captured before the
+        // app was torn down (e.g. the OS killed the WebView while backgrounded),
+        // seed the buffer from it instead of the now-stale disk copy, and mark
+        // the tab dirty so it still needs an explicit save. Also re-seed the
+        // Rust shadow so the next compile renders the restored buffer.
+        if (typeof unsavedContent === 'string' && viewMode === 'text') {
+            tab.content = unsavedContent;
+            tab.hasUnsavedChanges = true;
+            tab.isLoading = false;
+            updateFileContent(tab.absPath, unsavedContent).mapErr((err) =>
+                logError('restore unsaved shadow write failed:', err)
+            );
             return;
         }
 
@@ -240,6 +256,9 @@ class EditorStore {
 
         this._scheduleTypingPreview(tab);
         this._scheduleIdleSave(tab);
+        // Persist the unsaved buffer to durable storage (debounced) so it
+        // survives a non-graceful teardown — see getTabState / hot-exit restore.
+        workspace.schedulePersistTabs();
     }
 
     formatActiveFile(): ResultAsync<void, string> {
@@ -327,6 +346,9 @@ class EditorStore {
         // their newer content still needs to be persisted on the next pass.
         if (tab.content === contentToSave) {
             tab.hasUnsavedChanges = false;
+            // The tab is clean now; re-persist so it drops out of the durable
+            // unsaved map and a later restore doesn't resurrect stale edits.
+            workspace.schedulePersistTabs();
         }
     }
 
@@ -493,9 +515,15 @@ class EditorStore {
     private _scheduleIdleSave(tab: TabInfo): void {
         this._clearIdleSave(tab.id);
         if (!settings.autoSaveEnabled) return;
+        // On mobile, the OS can suspend/kill the app at any moment, so cap the
+        // idle-save delay aggressively to shrink the window where edits live
+        // only in memory.
+        const delay = platform.isMobile
+            ? Math.min(settings.autoSaveDelayMs, 600)
+            : settings.autoSaveDelayMs;
         this._idleSaveTimers.set(tab.id, setTimeout(() => {
             void this.flushTab(tab.id).catch(() => {});
-        }, settings.autoSaveDelayMs));
+        }, delay));
     }
 
     private _requestPreview(reason: CompileReason): void {
@@ -562,10 +590,20 @@ class EditorStore {
         map.set(newId, timer);
     }
 
-    getTabState(): { tabs: string[]; activeTabId: string | null } {
+    getTabState(): { tabs: string[]; activeTabId: string | null; unsaved: Record<string, string> } {
+        // Capture the live buffer of every dirty, editable text tab so it can be
+        // restored verbatim after a teardown (hot exit). Clean tabs are omitted
+        // — their content is already on disk.
+        const unsaved: Record<string, string> = {};
+        for (const t of this.tabs) {
+            if (t.isEditable && t.hasUnsavedChanges) {
+                unsaved[t.relPath] = t.content;
+            }
+        }
         return {
             tabs: this.tabs.map((t) => t.relPath),
             activeTabId: this.activeTabId,
+            unsaved,
         };
     }
 

--- a/apps/typwriter-desktop/src/lib/stores/onboarding.svelte.ts
+++ b/apps/typwriter-desktop/src/lib/stores/onboarding.svelte.ts
@@ -1,0 +1,373 @@
+import { okAsync, ResultAsync } from 'neverthrow';
+import {
+    getOnboardingCompleted,
+    openFolder,
+    prepareOnboardingWorkspace,
+    setMainFile,
+    setOnboardingCompleted,
+    triggerPreview,
+    updateFileContent,
+} from '$lib/ipc/commands';
+import { preview } from './preview.svelte';
+import { workspace } from './workspace.svelte';
+import { page } from './page.svelte';
+import { normalize } from '$lib/paths';
+import { logError } from '$lib/logger';
+
+/** Debounce for the typing → shadow-write → recompile path. Small enough to
+ *  feel live, large enough to coalesce same-burst keystrokes into one IPC. */
+const TYPING_PREVIEW_INTERVAL = 150;
+
+export interface OnboardingStep {
+    id: string;
+    title: string;
+    /** One or two short sentences introducing the concept. */
+    blurb: string;
+    /** Key syntax points, rendered as a compact list. */
+    bullets?: string[];
+    /** A concrete "now you try" nudge tied to the example. */
+    tryThis?: string;
+    /** Starter Typst the editor is seeded with when the step is first shown. */
+    example: string;
+}
+
+/** Tracks the "Writing in Typst" tutorial: markup, headings, emphasis, lists,
+ *  math, and the `#` function syntax — then points at the full docs. */
+export const ONBOARDING_STEPS: OnboardingStep[] = [
+    {
+        id: 'welcome',
+        title: 'Welcome to Typst',
+        blurb:
+            'Typst turns plain text you type on the left into a typeset document on the right. Try editing the text — the preview updates as you go.',
+        bullets: [
+            'The left pane is the editor — exactly the one you write documents in.',
+            'The right pane is a live preview of the compiled page.',
+        ],
+        tryThis: 'Change the heading text and watch the page update.',
+        example: `= Welcome to Typst
+
+Typst turns *plain text* into a beautifully typeset
+document. Edit the text on the left and watch the
+page on the right update instantly.
+`,
+    },
+    {
+        id: 'headings',
+        title: 'Headings & paragraphs',
+        blurb:
+            'Start a line with one or more equals signs to make a heading. Leave a blank line between blocks of text to start a new paragraph.',
+        bullets: [
+            '`=` is a top-level heading, `==` a section, `===` a subsection.',
+            'A blank line separates paragraphs.',
+        ],
+        tryThis: 'Add a `=== Subsection` and a second paragraph below it.',
+        example: `= Top-level heading
+== A section
+=== A subsection
+
+Leave a blank line between blocks of text and Typst
+starts a new paragraph.
+
+This is the second paragraph.
+`,
+    },
+    {
+        id: 'emphasis',
+        title: 'Bold & italic',
+        blurb:
+            'Wrap text in stars for bold, or underscores for italic. You can combine them for extra emphasis.',
+        bullets: [
+            '`*bold*` makes text bold.',
+            '`_italic_` makes text italic.',
+        ],
+        tryThis: 'Make your own name bold somewhere in the text.',
+        example: `You can make text *bold* with stars, and _italic_
+with underscores.
+
+You can even *_combine both_* when you really mean it.
+`,
+    },
+    {
+        id: 'lists',
+        title: 'Lists',
+        blurb:
+            'Begin lines with a hyphen for a bullet list, or a plus for a numbered list. Indent to nest items.',
+        bullets: [
+            '`-` starts a bullet list item.',
+            '`+` starts a numbered list item.',
+        ],
+        tryThis: 'Add a third step to the numbered list.',
+        example: `Shopping list:
+
+- Apples
+- Bread
+- Cheese
+
+Recipe:
+
++ Preheat the oven
++ Mix the dough
+`,
+    },
+    {
+        id: 'math',
+        title: 'Math',
+        blurb:
+            'Surround math with dollar signs. Keep it on the line for inline math, or give it space for a centered block equation.',
+        bullets: [
+            '`$a^2$` renders inline within a sentence.',
+            '`$ ... $` with spaces becomes a centered block.',
+        ],
+        tryThis: 'Change an exponent and watch the equation re-render.',
+        example: `Inline math like $a^2 + b^2 = c^2$ flows with the text.
+
+Block math gets its own centered line:
+
+$ sum_(i=1)^n i = (n (n + 1)) / 2 $
+`,
+    },
+    {
+        id: 'functions',
+        title: 'Functions & the #',
+        blurb:
+            'Markup is for writing prose. To call a function, switch to code with a leading #. Functions cover everything from coloured text to images and filler.',
+        bullets: [
+            '`#` switches from markup into code.',
+            '`#text(fill: blue)[…]` styles the bracketed content.',
+            '`#lorem(n)` inserts n words of placeholder text.',
+        ],
+        tryThis: 'Change the fill colour to `red`, or the word count in #lorem.',
+        example: `Markup is for writing; the \\#-prefix calls a function.
+
+#text(fill: blue)[This sentence is blue.]
+
+Need filler text while you draft? #lorem(20)
+`,
+    },
+    {
+        id: 'features',
+        title: 'Beyond writing',
+        blurb:
+            'The editor does more than typeset. Once a document takes shape, you can review it on a second screen, present it, or export it to share.',
+        bullets: [
+            'Pop the preview out into its own window — handy for a second monitor.',
+            'Enter presentation mode to show the document full-screen.',
+            'Export to PDF, PNG, or SVG from the preview toolbar.',
+        ],
+        tryThis: 'Find the export button in the preview toolbar and save this page as a PDF.',
+        example: `= Sharing your work
+
+Once a document is ready, Typwriter helps you take it
+further:
+
+- View the preview in a separate window
+- Present it full-screen
+- Export to *PDF*, *PNG*, or *SVG*
+`,
+    },
+    {
+        id: 'done',
+        title: "You're ready",
+        blurb:
+            'That covers the essentials: headings, emphasis, lists, math, and functions. The full documentation goes much further — templates, set rules, packages, and more.',
+        bullets: [
+            'Open the documentation to keep learning.',
+            'Or jump straight into writing your first document.',
+        ],
+        example: `= You're ready!
+
+You now know the basics of Typst — headings,
+emphasis, lists, math, and functions.
+
+Open the docs to keep going, or start writing your
+first real document.
+`,
+    },
+];
+
+class OnboardingStore {
+    /** Index of the currently shown step. */
+    stepIndex = $state(0);
+    /** True once the scratch workspace is open and the first step is rendered. */
+    ready = $state(false);
+    /** Bumped on step change / reset so the minimal editor reseeds its document
+     *  from the active buffer. Plain typing does NOT bump this — the editor is
+     *  the source of truth then. */
+    seedVersion = $state(0);
+    /** Set the moment the tutorial is finished/skipped this session. Guards the
+     *  in-session auto-show against a stale/failed persistence round-trip: the
+     *  store write can fail (e.g. disk full) and read back `false`, which would
+     *  otherwise bounce the user straight back into the tutorial after they exit. */
+    private sessionDismissed = false;
+
+    readonly steps = ONBOARDING_STEPS;
+
+    /** Absolute path of the opened scratch workspace. */
+    private rootPath = '';
+    /** Per-step editor content, seeded from each step's example and preserved
+     *  as the user navigates within a session (decision: edits are kept). */
+    private buffers: string[] = $state([]);
+    /** Debounce handle for the typing → recompile path. */
+    private previewTimer: ReturnType<typeof setTimeout> | null = null;
+
+    current = $derived(this.steps[this.stepIndex]);
+    isFirst = $derived(this.stepIndex === 0);
+    isLast = $derived(this.stepIndex === this.steps.length - 1);
+    /** Completion fraction (0–1) for a progress affordance. */
+    progress = $derived((this.stepIndex + 1) / this.steps.length);
+
+    /** Live content of the active step — what the minimal editor seeds from. */
+    activeContent = $derived(this.buffers[this.stepIndex] ?? '');
+
+    /** Each step is its own `*.typ` file, named by the step id. This is the
+     *  workspace-relative path `set_main_file` expects. */
+    private stepRelPath(index: number): string {
+        return `${this.steps[index].id}.typ`;
+    }
+
+    /** Absolute path, as `update_file_content` (shadow write) expects. */
+    private stepAbsPath(index: number): string {
+        return `${this.rootPath}/${this.stepRelPath(index)}`;
+    }
+
+    /** Open the scratch workspace and render the first step. */
+    enter(): ResultAsync<void, string> {
+        return ResultAsync.fromPromise(this._enter(), (err) => String(err));
+    }
+
+    private async _enter(): Promise<void> {
+        this.ready = false;
+        this.stepIndex = 0;
+        this.buffers = this.steps.map((step) => step.example);
+
+        const files = this.steps.map((step, i) => ({
+            name: this.stepRelPath(i),
+            content: this.buffers[i],
+        }));
+        const dirResult = await prepareOnboardingWorkspace(files);
+        if (dirResult.isErr()) throw new Error(dirResult.error);
+        this.rootPath = normalize(dirResult.value);
+
+        // Bind the editor world to the scratch dir. Talking to the world
+        // directly (no workspace/editor store) keeps the tutorial decoupled
+        // from the tabbed editor machinery.
+        const openResult = await openFolder(this.rootPath);
+        if (openResult.isErr()) throw new Error(openResult.error);
+
+        this.ready = true;
+        this.seedVersion += 1;
+        // Compile step 0. Because every step is a distinct main file, switching
+        // steps compiles a genuinely different document — the preview pipeline
+        // can never serve a previous step's cached render for the current one,
+        // which is what made the old single-file approach show a stale step.
+        this.activateStep();
+    }
+
+    next(): void {
+        this.goTo(this.stepIndex + 1);
+    }
+
+    prev(): void {
+        this.goTo(this.stepIndex - 1);
+    }
+
+    goTo(index: number): void {
+        if (index < 0 || index >= this.steps.length || index === this.stepIndex) {
+            return;
+        }
+        this.stepIndex = index;
+        this.seedVersion += 1;
+        this.activateStep();
+    }
+
+    /** Restore the pristine example for the current step. */
+    resetExample(): void {
+        this.buffers[this.stepIndex] = this.current.example;
+        this.seedVersion += 1;
+        this.activateStep();
+    }
+
+    /** Editor → store: the user typed. Keep the buffer in sync and schedule a
+     *  debounced shadow-write + recompile. */
+    handleContentChange(content: string): void {
+        this.buffers[this.stepIndex] = content;
+        this.scheduleTypingPreview();
+    }
+
+    /** Make the current step's file the main file, push its buffer into the
+     *  world's shadow, and force a fresh compile. Clearing first removes the
+     *  previous step's pages so there's no stale flash while this compiles. */
+    private activateStep(): void {
+        this.clearTimer();
+        const relPath = this.stepRelPath(this.stepIndex);
+        const absPath = this.stepAbsPath(this.stepIndex);
+        const content = this.buffers[this.stepIndex];
+        // Reflect the step's file as the workspace main file so the preview
+        // pane recognizes it (its empty-state copy reads `workspace.mainFile`).
+        workspace.mainFile = normalize(relPath);
+        preview.clear();
+        // `set_main_file` wants a workspace-relative path; `update_file_content`
+        // (the shadow write) wants the absolute path.
+        setMainFile(relPath)
+            .andThen(() => updateFileContent(absPath, content))
+            .andThen(() => triggerPreview('explicit'))
+            .mapErr((err) => logError('onboarding: activate step failed:', err));
+    }
+
+    private scheduleTypingPreview(): void {
+        if (this.previewTimer) return;
+        this.previewTimer = setTimeout(() => {
+            this.previewTimer = null;
+            const absPath = this.stepAbsPath(this.stepIndex);
+            const content = this.buffers[this.stepIndex];
+            updateFileContent(absPath, content)
+                .andThen(() => triggerPreview('typing'))
+                .mapErr((err) => logError('onboarding: typing preview failed:', err));
+        }, TYPING_PREVIEW_INTERVAL);
+    }
+
+    private clearTimer(): void {
+        if (this.previewTimer) {
+            clearTimeout(this.previewTimer);
+            this.previewTimer = null;
+        }
+    }
+
+    /** Finish or skip — both mark onboarding as shown and return home. */
+    finish(): ResultAsync<void, string> {
+        return ResultAsync.fromPromise(this._finish(), (err) => String(err));
+    }
+
+    skip(): ResultAsync<void, string> {
+        return this.finish();
+    }
+
+    private async _finish(): Promise<void> {
+        // Mark dismissed up front (synchronously) so the safety-net teardown in
+        // the page's onDestroy can't re-trigger a second finish, and so the home
+        // screen never re-shows the tutorial this session even if the persisted
+        // flag fails to write.
+        this.sessionDismissed = true;
+        this.clearTimer();
+        this.ready = false;
+        workspace.mainFile = null;
+
+        const flagResult = await setOnboardingCompleted(true);
+        if (flagResult.isErr()) {
+            // Non-fatal: worst case the user sees onboarding again next launch.
+            logError('onboarding: failed to persist completion flag:', flagResult.error);
+        }
+
+        this.stepIndex = 0;
+        page.navigate('home');
+    }
+
+    /** Whether onboarding should auto-show on launch. Desktop callers gate on
+     *  this after fonts are ready. */
+    shouldAutoShow(): ResultAsync<boolean, string> {
+        if (this.sessionDismissed) return okAsync(false);
+        return getOnboardingCompleted().map((completed) => !completed);
+    }
+}
+
+export const onboarding = new OnboardingStore();

--- a/apps/typwriter-desktop/src/lib/stores/page.svelte.ts
+++ b/apps/typwriter-desktop/src/lib/stores/page.svelte.ts
@@ -3,9 +3,10 @@ import Home from "$lib/components/pages/home.svelte"
 import Workspace from "$lib/components/pages/workspace.svelte"
 import Keymaps from "$lib/components/pages/keymaps.svelte"
 import Settings from "$lib/components/pages/settings.svelte"
+import Onboarding from "$lib/components/pages/onboarding.svelte"
 import type { Component } from "svelte"
 
-type PageName = "home" | "workspace" | "keymaps" | "settings"
+type PageName = "home" | "workspace" | "keymaps" | "settings" | "onboarding"
 
 type PageDefinition = {
     name: PageName
@@ -28,6 +29,10 @@ export const pages = {
     "settings": {
         name: "settings",
         component: Settings,
+    },
+    "onboarding": {
+        name: "onboarding",
+        component: Onboarding,
     },
 } satisfies Record<PageName, PageDefinition>
 

--- a/apps/typwriter-desktop/src/lib/stores/workspace.svelte.ts
+++ b/apps/typwriter-desktop/src/lib/stores/workspace.svelte.ts
@@ -230,9 +230,10 @@ class WorkspaceStore {
         const data = result.value;
         if (!data) return;
 
-        const [tabPaths, activeTabId] = data;
+        const [tabPaths, activeTabId, unsaved] = data;
         for (const relPath of tabPaths) {
-            await editor.openFile(relPath).match(
+            const override = unsaved?.[relPath] ?? unsaved?.[normalize(relPath)];
+            await editor.openFile(relPath, override).match(
                 () => {},
                 (err) => logError(`restore tab failed for ${relPath}:`, err),
             );
@@ -470,7 +471,7 @@ class WorkspaceStore {
     persistTabs(): void {
         if (!this.rootPath) return;
         const state = editor.getTabState();
-        saveWorkspaceTabs(state.tabs, state.activeTabId).mapErr((err) => {
+        saveWorkspaceTabs(state.tabs, state.activeTabId, state.unsaved).mapErr((err) => {
             logError('saveWorkspaceTabs failed:', err);
         });
     }

--- a/apps/typwriter-desktop/src/lib/stores/workspace.svelte.ts
+++ b/apps/typwriter-desktop/src/lib/stores/workspace.svelte.ts
@@ -231,17 +231,8 @@ class WorkspaceStore {
         if (!data) return;
 
         const [tabPaths, activeTabId, unsaved] = data;
-        for (const relPath of tabPaths) {
-            const override = unsaved?.[relPath] ?? unsaved?.[normalize(relPath)];
-            await editor.openFile(relPath, override).match(
-                () => {},
-                (err) => logError(`restore tab failed for ${relPath}:`, err),
-            );
-        }
-
-        if (activeTabId && editor.tabs.find((t) => t.id === activeTabId)) {
-            await editor.activateTab(activeTabId);
-        }
+        // Loads every tab's content concurrently and activates the saved tab.
+        await editor.restoreTabs(tabPaths, activeTabId, unsaved ?? {});
 
         if (editor.activeTab) {
             this.activeFilePath = editor.activeTab.relPath;

--- a/apps/typwriter-desktop/src/lib/types.ts
+++ b/apps/typwriter-desktop/src/lib/types.ts
@@ -43,7 +43,9 @@ export type JumpResponse =
 /** Internally-tagged union (discriminant: `type`). */
 export type FileContentResponse =
     | { type: 'text'; content: string }
-    | { type: 'image'; path: string; mime: string }
+    // `data` is an inline `data:` URL, set only for SAF workspace roots where
+    // the asset protocol can't reach `path`; the frontend prefers it when present.
+    | { type: 'image'; path: string; mime: string; data?: string | null }
     | { type: 'unsupported' };
 
 // ─── Click / Jump ─────────────────────────────────────────────────────────────

--- a/apps/typwriter-desktop/src/lib/types.ts
+++ b/apps/typwriter-desktop/src/lib/types.ts
@@ -151,7 +151,8 @@ export type CommitTrigger =
     | 'manual'
     | 'save'
     | 'compile'
-    | 'pre_restore';
+    | 'pre_restore'
+    | 'file_op';
 
 export interface RestorePoint {
     /** Full 64-char sha-256 hex snapshot id. */

--- a/apps/typwriter-desktop/src/lib/typst-codemirror-lang/lezer-typst/markup.ts
+++ b/apps/typwriter-desktop/src/lib/typst-codemirror-lang/lezer-typst/markup.ts
@@ -839,6 +839,12 @@ function parseMarkupUntilNewline(s: Scanner, ctx: TypstParseContext): Elt[] {
       continue
     }
 
+    // Link: auto-detect http:// or https://
+    if (ch === Ch.h) {
+      const elt = tryParseLink(s)
+      if (elt) { flushText(); elts.push(elt); continue }
+    }
+
     // Line comment
     if (ch === Ch.Slash && s.peek(1) === Ch.Slash) {
       flushText()

--- a/apps/typwriter-desktop/src/routes/+layout.svelte
+++ b/apps/typwriter-desktop/src/routes/+layout.svelte
@@ -10,6 +10,9 @@
   import { settings } from "$lib/stores/settings.svelte";
   import { onAppFontsLoaded } from "$lib/ipc/events";
   import { installKeyboardAvoider } from "$lib/hooks/mobile-keyboard";
+  import { workspace } from "$lib/stores/workspace.svelte";
+  import { editor } from "$lib/stores/editor.svelte";
+  import { editorSearch } from "$lib/stores/editor-search.svelte";
 
   const { children } = $props();
   let appliedTheme: string | undefined;
@@ -23,6 +26,41 @@
     // No-op on desktop. Keeps focused inputs above the soft keyboard on
     // Android by listening to visualViewport changes.
     return installKeyboardAvoider();
+  });
+
+  // ── Persist + flush before the app is suspended/killed ────────────────────
+  //
+  // On mobile the OS can tear down the WebView (and the Rust process with it)
+  // the moment the app is backgrounded — none of the in-app flush paths
+  // (closeTab / leave / init) run, so unsaved content that lives only in
+  // memory would be lost. `visibilitychange → hidden` and `pagehide` are the
+  // reliable web-lifecycle signals that fire *before* that teardown.
+  $effect(() => {
+    if (typeof document === "undefined") return;
+
+    const flush = () => {
+      // Force CodeMirror to commit any in-progress IME composition (Gboard
+      // composes a word before it lands in the document) so the latest
+      // keystrokes are mirrored into the store before we persist.
+      editorSearch.getActiveView()?.contentDOM.blur();
+      // Snapshot the (now durable) unsaved buffers, then save dirty tabs to
+      // disk. persistTabs is synchronous up to the IPC call; flushAllTabs is
+      // best-effort — if the OS suspends mid-flush, the durable snapshot from
+      // persistTabs still covers us via hot-exit restore.
+      workspace.persistTabs();
+      void editor.flushAllTabs();
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("pagehide", flush);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("pagehide", flush);
+    };
   });
 
   onMount(async () => {

--- a/apps/typwriter-web/src/routes/+page.svelte
+++ b/apps/typwriter-web/src/routes/+page.svelte
@@ -354,7 +354,16 @@
 			<div class="flex items-center gap-2 text-sm font-medium">
 				<HugeiconsIcon icon={AndroidIcon} size={15} class="text-muted-foreground" />
 				Android
+				<span
+					class="rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[0.625rem] font-medium tracking-wide text-amber-600 uppercase dark:text-amber-400"
+				>
+					Experimental
+				</span>
 			</div>
+			<p class="text-xs text-muted-foreground">
+				The Android build is highly experimental — expect bugs, missing features, and breaking
+				changes. Back up your work and don't rely on it for anything important yet.
+			</p>
 			{#if androidAssets.length > 0}
 				{#each androidAssets as asset (asset.name)}
 					<Button

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "apps/typwriter-desktop": {
       "name": "typwriter",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@citedrive/codemirror-lang-bibtex": "^6.4.1",
         "@codemirror/autocomplete": "^6.20.0",


### PR DESCRIPTION
This pull request introduces a comprehensive onboarding tutorial for the Typwriter desktop app, focused on teaching new users the basics of Typst markup through an interactive, multi-step experience. The onboarding is implemented as a first-class page, with a scratch workspace for live editing and preview, and is shown automatically on first launch (desktop only). Several backend and frontend changes support this, including new Tauri commands, a persistent onboarding-completed flag, and improvements to workspace handling. Additional minor changes include version bumps and a note about Android support.

**Onboarding Tutorial Implementation:**

* Added a detailed onboarding design document outlining goals, architecture, and implementation notes for the interactive tutorial, including step content and the rationale for architectural decisions.
* Introduced a new onboarding page and store in the frontend, with navigation, per-step state, and replay functionality from the home screen.
* Onboarding uses a scratch workspace seeded with one file per step, ensuring preview cache correctness and instant replay. [[1]](diffhunk://#diff-d9f0044333bea8e32a211f290556d9f557823a20381f39c5ac64e8086292a156R1-R340) [[2]](diffhunk://#diff-591f6fadd542ea1ddb3dff59b96fbb91f3e72ee6e2654bb981576b6936ee453cL1-R64)

**Backend (Rust) Support:**

* Added Tauri commands to prepare the onboarding workspace (`prepare_onboarding_workspace`), create per-step files, and manage the onboarding-completed flag, ensuring the onboarding flow is tracked and replayable. [[1]](diffhunk://#diff-591f6fadd542ea1ddb3dff59b96fbb91f3e72ee6e2654bb981576b6936ee453cL1-R64) [[2]](diffhunk://#diff-d9f0044333bea8e32a211f290556d9f557823a20381f39c5ac64e8086292a156R1-R340)
* Updated the font loading check to use the world state, and improved documentation/comments for onboarding-related commands.

**Frontend/IPC Integration:**

* Added IPC wrappers for onboarding commands and integrated onboarding flow into the home page's first-launch logic and footer.

**Other Improvements and Maintenance:**

* Bumped version numbers in `package.json` and `Cargo.toml` to 0.8.1. [[1]](diffhunk://#diff-cbc67698e354919ddff558e2b70fea75386c868fa834faa9691e3785cdd7f49eL3-R3) [[2]](diffhunk://#diff-b831b8227482fc56f30d719920e1617f662d09243a6b6ef5f698fa6f6c162bdbL3-R3)
* Added a note to the `README.md` clarifying that Android support is currently buggy and not a focus.
* Updated internal documentation (`CLAUDE.md`) to reflect changes in font loading and preview caching for onboarding.

**Android/SAF Support:**

* Extended `read_file` to optionally return image data as an inline `data:` URL for workspaces opened via Android's Storage Access Framework, improving compatibility for image previews on Android. [[1]](diffhunk://#diff-a20d449ef0aa6ac081dd5364ad26cc7b489263286c6a71b421d59573b7a7cbd9L137-R168) [[2]](diffhunk://#diff-a20d449ef0aa6ac081dd5364ad26cc7b489263286c6a71b421d59573b7a7cbd9R11)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a multi-step interactive onboarding tutorial for Typwriter, backed by a disposable scratch workspace under app-data, alongside three orthogonal improvements: lazy font loading, SAF-aware file I/O throughout the Rust backend, and hot-exit tab restore.

- **Onboarding**: A new `OnboardingStore` drives an 8-step tutorial through a dedicated page with a minimal CodeMirror editor and live preview pane. Each step is its own `.typ` file in the scratch workspace; the preview manifest (`preview-manifest.json`) lets cached pages paint immediately before fonts finish loading.
- **Lazy fonts + preview manifest**: `EditorWorld::ensure_fonts_loading` replaces the eager startup thread; the compile worker calls `wait_until_fonts_loaded` via a `Condvar` to avoid rendering against the empty font book.
- **SAF + hot-exit**: All structural workspace ops route through `WorkingTreeFs`; `save_workspace_tabs` gains an `unsaved` map and `editor.restoreTabs` rehydrates dirty buffers concurrently.

<h3>Confidence Score: 3/5</h3>

The SAF, hot-exit, and font-loading infrastructure changes are well-structured. The onboarding store's `activateStep` has a design gap where rapid step navigation dispatches unsequenced concurrent IPC chains that can leave the Rust main-file pointer at the wrong step.

Three independent feature areas (lazy fonts, SAF I/O, hot-exit) are implemented carefully with proper mutex/condvar patterns and backward-compatible persistence. The onboarding store's `activateStep` method launches a fire-and-forget chain with no way to cancel or supersede an in-flight chain from a previous step — a user clicking through the dot-stepper quickly can land in a state where the preview shows a different step than the sidebar text.

`onboarding.svelte.ts` (activateStep sequencing), `vcs/fs.rs` (default rename atomicity on Android), `home.svelte` (font-loading feedback gap).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/typwriter-desktop/src/lib/stores/onboarding.svelte.ts | New onboarding store with per-step buffers, workspace entry/exit, and typing debounce; concurrent `activateStep` IPC chains lack sequencing, risking wrong-step preview on rapid navigation. |
| apps/typwriter-desktop/src-tauri/src/vcs/fs.rs | Adds `remove_dir_all`, `rename`, `copy_tree`, and `remove_tree` default methods to `WorkingTreeFs`; the default `rename` is a non-atomic copy+delete that can leave both source and destination on partial failure. |
| apps/typwriter-desktop/src-tauri/src/commands/app.rs | Refactors `is_fonts_loaded` to read from `EditorWorld` directly, adds `prepare_onboarding_workspace` with path-traversal guard; logic is correct. |
| apps/typwriter-desktop/src-tauri/src/commands/editor.rs | Extends `read_file` and `save_file` to route through the SAF-aware `WorkingTreeFs`, adds inline `data:` URL encoding for SAF image reads; logic and error handling are correct. |
| apps/typwriter-desktop/src-tauri/src/world/mod.rs | Adds lazy-font-loading machinery (AtomicBool spawn guard, Condvar wait, `ensure_fonts_loading`), SAF-aware `read_file_bytes`, and `VcsState` reference; concurrency design is correct. |
| apps/typwriter-desktop/src-tauri/src/workspace/mod.rs | Routes all structural file ops through the SAF-aware `WorkingTreeFs`, adds VCS snapshot on every operation, and switches `get_file_tree` to the accessor; `working_fs()` helper is clean. |
| apps/typwriter-desktop/src-tauri/src/workspace/store.rs | Adds `unsaved` hot-exit buffer to tab persistence and filters onboarding workspace from recent-workspaces list; backward-compatible deserialization is correct. |
| apps/typwriter-desktop/src-tauri/src/compiler/mod.rs | Adds `restore_preview` to paint cached pages before the font-blocked recompile, writes the manifest after each successful compile, and calls `ensure_fonts_loading`/`wait_until_fonts_loaded` in the compile worker. |
| apps/typwriter-desktop/src/lib/stores/editor.svelte.ts | Adds concurrent `restoreTabs` (replaces sequential loop), hot-exit unsaved-buffer capture/restore, SAF image source helper, and mobile preview/save-delay adjustments; logic is sound. |
| apps/typwriter-desktop/src/routes/+layout.svelte | Adds `visibilitychange`/`pagehide` flush for hot-exit on mobile; cleanup is properly returned from the `$effect`, and the IME-flush blur is guarded with optional chaining. |
| apps/typwriter-desktop/src/lib/components/pages/onboarding.svelte | New onboarding page with resizable editor/preview layout and step navigation; `onDestroy` calls `preview.destroy()` unconditionally even when `preview.init()` may have thrown. |
| apps/typwriter-desktop/src/lib/components/pages/home.svelte | Removes `fontsReady` guard and toast, adds onboarding auto-show check and Tutorial footer button; users lose all font-loading feedback during the compile-blocked window. |
| apps/typwriter-desktop/src-tauri/src/vcs/mod.rs | Adds `working_tree_fs_for` and `is_saf_root` helpers, extends `SnapshotPolicy::allows` to pass `FileOp` through; clean and correct. |
| apps/typwriter-desktop/src-tauri/src/compiler/disk_cache.rs | Adds `write_manifest`/`read_manifest` for persisting ordered page keys between sessions; error handling is best-effort and logged, as intended. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Onboarding Page
    participant Store as OnboardingStore
    participant IPC as Tauri IPC
    participant Rust as WorkspaceState / World
    participant Compiler as PreviewPipeline

    UI->>Store: enter()
    Store->>IPC: prepareOnboardingWorkspace(files)
    IPC->>Rust: "create scratch dir, seed *.typ files"
    Rust-->>IPC: scratchPath
    Store->>IPC: openFolder(scratchPath)
    IPC->>Rust: open_folder → ensure_fonts_loading, attach_disk_cache
    Rust->>Compiler: restore_preview(main_rel)
    Compiler-->>UI: preview:page-updated (cached pages)
    Rust-->>IPC: ok
    Store->>Store: activateStep(0)
    Store->>IPC: setMainFile(welcome.typ)
    Store->>IPC: updateFileContent(absPath, content)
    Store->>IPC: triggerPreview(explicit)
    IPC->>Rust: world.wait_until_fonts_loaded → compile
    Compiler-->>UI: preview:page-updated (fresh compile)

    Note over Store,IPC: On step navigation (goTo)
    UI->>Store: goTo(N)
    Store->>Store: activateStep(N) — concurrent chain, no cancel of N-1
    Store->>IPC: setMainFile(stepN.typ)
    Store->>IPC: updateFileContent(stepN, content)
    Store->>IPC: triggerPreview(explicit)

    Note over UI,Store: On finish/skip
    UI->>Store: finish()
    Store->>IPC: setOnboardingCompleted(true)
    Store->>Store: page.navigate(home)
```

<sub>Reviews (1): Last reviewed commit: ["Add Android experimental notice in UI an..."](https://github.com/ahdeyyy/typwriter/commit/9baf8a51197cd1190185016d1c5b1c2601a1535b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36108158)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->